### PR TITLE
Added check to targetType as it can be undefined

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -160,7 +160,7 @@ export class TransformOperationExecutor {
                 if (!this.isCircular(subValue, level)) {
                     let transformKey = this.transformationType === "plainToClass" ? newValueKey : key;
                     let finalValue = this.transform(subSource, subValue, type, arrayType, isSubValueMap, level + 1);
-                    if(targetType) {
+                    if (targetType) {
                         finalValue = this.applyCustomTransformations(finalValue, targetType, transformKey);
                     }
                     if (newValue instanceof Map) {

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -160,7 +160,9 @@ export class TransformOperationExecutor {
                 if (!this.isCircular(subValue, level)) {
                     let transformKey = this.transformationType === "plainToClass" ? newValueKey : key;
                     let finalValue = this.transform(subSource, subValue, type, arrayType, isSubValueMap, level + 1);
-                    finalValue = this.applyCustomTransformations(finalValue, targetType, transformKey);
+                    if(targetType) {
+                        finalValue = this.applyCustomTransformations(finalValue, targetType, transformKey);
+                    }
                     if (newValue instanceof Map) {
                         newValue.set(newValueKey, finalValue);
                     } else {

--- a/test/functional/custom-transform.spec.ts
+++ b/test/functional/custom-transform.spec.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
-import {classToPlain, plainToClass} from "../../src/index";
-import {defaultMetadataStorage} from "../../src/storage";
-import {Exclude, Expose, Transform, Type} from "../../src/decorators";
+import { classToPlain, plainToClass } from "../../src/index";
+import { defaultMetadataStorage } from "../../src/storage";
+import { Expose, Transform, Type } from "../../src/decorators";
 import * as moment from "moment";
 
 describe("custom transformation decorator", () => {
@@ -22,6 +22,8 @@ describe("custom transformation decorator", () => {
 
         const classedUser = plainToClass(User, plainUser);
         classedUser.name.should.be.equal("JOHNY CAGE");
+
+        plainToClass(User, plainUser);
     });
 
     it("@Transform decorator logic should be executed depend of toPlainOnly and toClassOnly set", () => {
@@ -33,8 +35,8 @@ describe("custom transformation decorator", () => {
 
             name: string;
 
-            @Transform(value => value.toString(), { toPlainOnly: true })
-            @Transform(value => moment(value), { toClassOnly: true })
+            @Transform(value => value.toString(), {toPlainOnly: true})
+            @Transform(value => moment(value), {toClassOnly: true})
             date: Date;
 
         }
@@ -66,8 +68,9 @@ describe("custom transformation decorator", () => {
 
     });
 
-    it("versions and groups should work with @Transform decorator too", () => {
+    it("Non class objects should not break if transform is used", () => {
         defaultMetadataStorage.clear();
+
 
         class User {
 
@@ -75,52 +78,40 @@ describe("custom transformation decorator", () => {
 
             name: string;
 
-            @Type(() => Date)
-            @Transform(value => moment(value), { since: 1, until: 2 })
-            date: Date;
+            @Type(() => Test)
+            @Transform(value => ArrayUtil.toArray<Test>(value))
+            date: Test[];
 
             @Type(() => Date)
-            @Transform(value => value.toString(), { groups: ["user"] })
             lastVisitDate: Date;
 
         }
 
-        let plainUser = {
-            id: 1,
-            name: "Johny Cage",
-            date: new Date().valueOf(),
-            lastVisitDate: new Date().valueOf()
+        class ArrayUtil {
+            public static toArray<T>(object: T): T[] {
+                let obj = new Array<any>();
+
+                if (!(object instanceof Array)) {
+                    obj.push(object);
+                } else {
+                    obj = object;
+                }
+
+                return obj;
+            }
+        }
+
+
+        class Test {
+            test: string;
+        }
+
+        let plainBuilding = {
+            address: "1234 Purple Drive"
         };
 
-        const classedUser1 = plainToClass(User, plainUser);
-        classedUser1.should.be.instanceOf(User);
-        classedUser1.id.should.be.equal(1);
-        classedUser1.name.should.be.equal("Johny Cage");
-        moment.isMoment(classedUser1.date).should.be.true;
-
-        const classedUser2 = plainToClass(User, plainUser, { version: 0.5 });
-        classedUser2.should.be.instanceOf(User);
-        classedUser2.id.should.be.equal(1);
-        classedUser2.name.should.be.equal("Johny Cage");
-        classedUser2.date.should.be.instanceof(Date);
-
-        const classedUser3 = plainToClass(User, plainUser, { version: 1 });
-        classedUser3.should.be.instanceOf(User);
-        classedUser3.id.should.be.equal(1);
-        classedUser3.name.should.be.equal("Johny Cage");
-        moment.isMoment(classedUser3.date).should.be.true;
-
-        const classedUser4 = plainToClass(User, plainUser, { version: 2 });
-        classedUser4.should.be.instanceOf(User);
-        classedUser4.id.should.be.equal(1);
-        classedUser4.name.should.be.equal("Johny Cage");
-        classedUser4.date.should.be.instanceof(Date);
-
-        const classedUser5 = plainToClass(User, plainUser, { groups: ["user"] });
-        classedUser5.should.be.instanceOf(User);
-        classedUser5.id.should.be.equal(1);
-        classedUser5.name.should.be.equal("Johny Cage");
-        classedUser5.lastVisitDate.should.be.equal(new Date(plainUser.lastVisitDate).toString());
+        let test = classToPlain({"success": true});
+        test.should.be.eql({"success": true});
     });
 
 

--- a/test/functional/custom-transform.spec.ts
+++ b/test/functional/custom-transform.spec.ts
@@ -26,6 +26,63 @@ describe("custom transformation decorator", () => {
         plainToClass(User, plainUser);
     });
 
+    it("versions and groups should work with @Transform decorator too", () => {
+        defaultMetadataStorage.clear();
+
+        class User {
+
+            id: number;
+
+            name: string;
+
+            @Type(() => Date)
+            @Transform(value => moment(value), { since: 1, until: 2 })
+            date: Date;
+
+            @Type(() => Date)
+            @Transform(value => value.toString(), { groups: ["user"] })
+            lastVisitDate: Date;
+
+        }
+
+        let plainUser = {
+            id: 1,
+            name: "Johny Cage",
+            date: new Date().valueOf(),
+            lastVisitDate: new Date().valueOf()
+        };
+
+        const classedUser1 = plainToClass(User, plainUser);
+        classedUser1.should.be.instanceOf(User);
+        classedUser1.id.should.be.equal(1);
+        classedUser1.name.should.be.equal("Johny Cage");
+        moment.isMoment(classedUser1.date).should.be.true;
+
+        const classedUser2 = plainToClass(User, plainUser, { version: 0.5 });
+        classedUser2.should.be.instanceOf(User);
+        classedUser2.id.should.be.equal(1);
+        classedUser2.name.should.be.equal("Johny Cage");
+        classedUser2.date.should.be.instanceof(Date);
+
+        const classedUser3 = plainToClass(User, plainUser, { version: 1 });
+        classedUser3.should.be.instanceOf(User);
+        classedUser3.id.should.be.equal(1);
+        classedUser3.name.should.be.equal("Johny Cage");
+        moment.isMoment(classedUser3.date).should.be.true;
+
+        const classedUser4 = plainToClass(User, plainUser, { version: 2 });
+        classedUser4.should.be.instanceOf(User);
+        classedUser4.id.should.be.equal(1);
+        classedUser4.name.should.be.equal("Johny Cage");
+        classedUser4.date.should.be.instanceof(Date);
+
+        const classedUser5 = plainToClass(User, plainUser, { groups: ["user"] });
+        classedUser5.should.be.instanceOf(User);
+        classedUser5.id.should.be.equal(1);
+        classedUser5.name.should.be.equal("Johny Cage");
+        classedUser5.lastVisitDate.should.be.equal(new Date(plainUser.lastVisitDate).toString());
+    });
+
     it("@Transform decorator logic should be executed depend of toPlainOnly and toClassOnly set", () => {
         defaultMetadataStorage.clear();
 


### PR DESCRIPTION
targetType can be undefined if there is no class to map to. This happens if you use class-transformer with routing-controllers but do not have explicit classes defined for all objects. You also have to have a custom transformer defined to hit this condition.