### PR TITLE
expose storage as public api & use it as global variable

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -1,5 +1,5 @@
 import {ClassTransformOptions} from "./ClassTransformOptions";
-import {defaultMetadataStorage} from "./storage";
+import {getDefaultMetadataStorage} from "./storage";
 import {TypeOptions} from "./metadata/ExposeExcludeOptions";
 import {ExposeMetadata} from "./metadata/ExposeMetadata";
 
@@ -100,14 +100,14 @@ export class TransformOperationExecutor {
                 let valueKey = key, newValueKey = key, propertyName = key;
                 if (!this.options.ignoreDecorators && targetType) {
                     if (this.transformationType === "plainToClass") {
-                        const exposeMetadata = defaultMetadataStorage.findExposeMetadataByCustomName(targetType, key);
+                        const exposeMetadata = getDefaultMetadataStorage().findExposeMetadataByCustomName(targetType, key);
                         if (exposeMetadata) {
                             propertyName = exposeMetadata.propertyName;
                             newValueKey = exposeMetadata.propertyName;
                         }
 
                     } else if (this.transformationType === "classToPlain" || this.transformationType === "classToClass") {
-                        const exposeMetadata = defaultMetadataStorage.findExposeMetadata(targetType, key);
+                        const exposeMetadata = getDefaultMetadataStorage().findExposeMetadata(targetType, key);
                         if (exposeMetadata && exposeMetadata.options && exposeMetadata.options.name)
                             newValueKey = exposeMetadata.options.name;
                     }
@@ -129,7 +129,7 @@ export class TransformOperationExecutor {
                     type = targetType;
 
                 } else if (targetType) {
-                    const metadata = defaultMetadataStorage.findTypeMetadata(targetType, propertyName);
+                    const metadata = getDefaultMetadataStorage().findTypeMetadata(targetType, propertyName);
                     if (metadata) {
                         const options: TypeOptions = { newObject: newValue, object: value, property: propertyName };
                         type = metadata.typeFunction(options);
@@ -187,7 +187,7 @@ export class TransformOperationExecutor {
     }
 
     private applyCustomTransformations(value: any, target: Function, key: string) {
-        let metadatas = defaultMetadataStorage.findTransformMetadatas(target, key, this.transformationType);
+        let metadatas = getDefaultMetadataStorage().findTransformMetadatas(target, key, this.transformationType);
 
         // apply versioning options
         if (this.options.version !== undefined) {
@@ -230,14 +230,14 @@ export class TransformOperationExecutor {
 
     private getReflectedType(target: Function, propertyName: string) {
         if (!target) return undefined;
-        const meta = defaultMetadataStorage.findTypeMetadata(target, propertyName);
+        const meta = getDefaultMetadataStorage().findTypeMetadata(target, propertyName);
         return meta ? meta.reflectedType : undefined;
     }
 
     private getKeys(target: Function, object: Object): string[] {
 
         // determine exclusion strategy
-        let strategy = defaultMetadataStorage.getStrategy(target);
+        let strategy = getDefaultMetadataStorage().getStrategy(target);
         if (strategy === "none")
             strategy = this.options.strategy || "exposeAll"; // exposeAll is default strategy
 
@@ -254,10 +254,10 @@ export class TransformOperationExecutor {
         if (!this.options.ignoreDecorators && target) {
 
             // add all exposed to list of keys
-            let exposedProperties = defaultMetadataStorage.getExposedProperties(target, this.transformationType);
+            let exposedProperties = getDefaultMetadataStorage().getExposedProperties(target, this.transformationType);
             if (this.transformationType === "plainToClass") {
                 exposedProperties = exposedProperties.map(key => {
-                    const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key);
+                    const exposeMetadata = getDefaultMetadataStorage().findExposeMetadata(target, key);
                     if (exposeMetadata && exposeMetadata.options && exposeMetadata.options.name) {
                         return exposeMetadata.options.name;
                     }
@@ -268,7 +268,7 @@ export class TransformOperationExecutor {
             keys = keys.concat(exposedProperties);
 
             // exclude excluded properties
-            const excludedProperties = defaultMetadataStorage.getExcludedProperties(target, this.transformationType);
+            const excludedProperties = getDefaultMetadataStorage().getExcludedProperties(target, this.transformationType);
             if (excludedProperties.length > 0) {
                 keys = keys.filter(key => {
                     return excludedProperties.indexOf(key) === -1;
@@ -278,7 +278,7 @@ export class TransformOperationExecutor {
             // apply versioning options
             if (this.options.version !== undefined) {
                 keys = keys.filter(key => {
-                    const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key);
+                    const exposeMetadata = getDefaultMetadataStorage().findExposeMetadata(target, key);
                     if (!exposeMetadata || !exposeMetadata.options)
                         return true;
 
@@ -289,7 +289,7 @@ export class TransformOperationExecutor {
             // apply grouping options
             if (this.options.groups && this.options.groups.length) {
                 keys = keys.filter(key => {
-                    const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key);
+                    const exposeMetadata = getDefaultMetadataStorage().findExposeMetadata(target, key);
                     if (!exposeMetadata || !exposeMetadata.options)
                         return true;
 
@@ -297,7 +297,7 @@ export class TransformOperationExecutor {
                 });
             } else {
                 keys = keys.filter(key => {
-                    const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key);
+                    const exposeMetadata = getDefaultMetadataStorage().findExposeMetadata(target, key);
                     return  !exposeMetadata ||
                             !exposeMetadata.options ||
                             !exposeMetadata.options.groups ||

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,5 @@
 import {ClassTransformer} from "./ClassTransformer";
-import {defaultMetadataStorage} from "./storage";
+import {getDefaultMetadataStorage} from "./storage";
 import {TypeMetadata} from "./metadata/TypeMetadata";
 import {ExposeMetadata} from "./metadata/ExposeMetadata";
 import {ExposeOptions, ExcludeOptions, TypeOptions, TransformOptions} from "./metadata/ExposeExcludeOptions";
@@ -13,7 +13,7 @@ import {ClassTransformOptions} from "./ClassTransformOptions";
 export function Transform(transformFn: (value: any) => any, options?: TransformOptions) {
     return function(target: any, key: string) {
         const metadata = new TransformMetadata(target.constructor, key, transformFn, options);
-        defaultMetadataStorage.addTransformMetadata(metadata);
+        getDefaultMetadataStorage().addTransformMetadata(metadata);
     };
 }
 
@@ -24,7 +24,7 @@ export function Type(typeFunction?: (type?: TypeOptions) => Function) {
     return function(target: any, key: string) {
         const type = (Reflect as any).getMetadata("design:type", target, key);
         const metadata = new TypeMetadata(target.constructor, key, type, typeFunction);
-        defaultMetadataStorage.addTypeMetadata(metadata);
+        getDefaultMetadataStorage().addTypeMetadata(metadata);
     };
 }
 
@@ -36,7 +36,7 @@ export function Type(typeFunction?: (type?: TypeOptions) => Function) {
 export function Expose(options?: ExposeOptions) {
     return function(object: Object|Function, propertyName?: string) {
         const metadata = new ExposeMetadata(object instanceof Function ? object : object.constructor, propertyName, options || {});
-        defaultMetadataStorage.addExposeMetadata(metadata);
+        getDefaultMetadataStorage().addExposeMetadata(metadata);
     };
 }
 
@@ -48,7 +48,7 @@ export function Expose(options?: ExposeOptions) {
 export function Exclude(options?: ExcludeOptions) {
     return function(object: Object|Function, propertyName?: string) {
         const metadata = new ExcludeMetadata(object instanceof Function ? object : object.constructor, propertyName, options || {});
-        defaultMetadataStorage.addExcludeMetadata(metadata);
+        getDefaultMetadataStorage().addExcludeMetadata(metadata);
     };
 }
 
@@ -60,10 +60,10 @@ export function TransformClassToPlain(params?: ClassTransformOptions): Function 
     return function (target: Function, propertyKey: string, descriptor: PropertyDescriptor) {
         const classTransformer: ClassTransformer = new ClassTransformer();
         const originalMethod = descriptor.value;
-        
+
         descriptor.value = function(...args: any[]) {
             const result: any = originalMethod.apply(this, args);
-            const isPromise = !!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function";          
+            const isPromise = !!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function";
 
             return isPromise ? result.then((data: any) => classTransformer.classToPlain(data, params)) : classTransformer.classToPlain(result, params);
         };
@@ -78,7 +78,7 @@ export function TransformClassToClass(params?: ClassTransformOptions): Function 
     return function (target: Function, propertyKey: string, descriptor: PropertyDescriptor) {
         const classTransformer: ClassTransformer = new ClassTransformer();
         const originalMethod = descriptor.value;
-        
+
         descriptor.value = function(...args: any[]) {
             const result: any = originalMethod.apply(this, args);
             const isPromise = !!result && (typeof result === "object" || typeof result === "function") && typeof result.then === "function";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export {ClassTransformer} from "./ClassTransformer";
 export {ClassTransformOptions} from "./ClassTransformOptions";
 export * from "./metadata/ExposeExcludeOptions";
 export * from "./decorators";
+export * from "./storage";
 
 const classTransformer = new ClassTransformer();
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -11,8 +11,8 @@ import { MetadataStorage } from "./metadata/MetadataStorage";
  * Metadata args storage follows the best practices and stores metadata in a global variable.
  */
 export function getDefaultMetadataStorage(): MetadataStorage {
-    if (!(global as any).routingControllersMetadataArgsStorage)
-        (global as any).routingControllersMetadataArgsStorage = new MetadataStorage();
+    if (!(global as any).classTranformerMetadataStorage)
+        (global as any).classTranformerMetadataStorage = new MetadataStorage();
 
-    return (global as any).routingControllersMetadataArgsStorage;
+    return (global as any).classTranformerMetadataStorage;
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,18 @@
-import {MetadataStorage} from "./metadata/MetadataStorage";
+import { MetadataStorage } from "./metadata/MetadataStorage";
 
 /**
  * Default metadata storage is used as singleton and can be used to storage all metadatas.
  */
-export const defaultMetadataStorage = new MetadataStorage();
+// export const getDefaultMetadataStorage() = new MetadataStorage();
+
+
+/**
+ * Gets metadata args storage.
+ * Metadata args storage follows the best practices and stores metadata in a global variable.
+ */
+export function getDefaultMetadataStorage(): MetadataStorage {
+    if (!(global as any).routingControllersMetadataArgsStorage)
+        (global as any).routingControllersMetadataArgsStorage = new MetadataStorage();
+
+    return (global as any).routingControllersMetadataArgsStorage;
+}

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -6,14 +6,14 @@ import {
     plainToClassFromExist,
     classToClass, classToClassFromExist
 } from "../../src/index";
-import {defaultMetadataStorage} from "../../src/storage";
+import {getDefaultMetadataStorage} from "../../src/storage";
 import {Exclude, Expose, Type} from "../../src/decorators";
 import {expect} from "chai";
 
 describe("basic functionality", () => {
 
     it("should convert instance of the given object to plain javascript object and should expose all properties since its a default behaviour", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
             id: number;
@@ -95,7 +95,7 @@ describe("basic functionality", () => {
     });
 
     it("should exclude all objects marked with @Exclude() decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
             id: number;
@@ -174,7 +174,7 @@ describe("basic functionality", () => {
     });
 
     it("should exclude all properties from object if whole class is marked with @Exclude() decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         @Exclude()
         class User {
@@ -239,7 +239,7 @@ describe("basic functionality", () => {
     });
 
     it("should exclude all properties from object if whole class is marked with @Exclude() decorator, but include properties marked with @Expose() decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         @Exclude()
         class User {
@@ -323,7 +323,7 @@ describe("basic functionality", () => {
     });
 
     it("should exclude all properties from object if its defined via transformation options, but include properties marked with @Expose() decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -406,7 +406,7 @@ describe("basic functionality", () => {
     });
 
     it("should expose all properties from object if its defined via transformation options, but exclude properties marked with @Exclude() decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -484,7 +484,7 @@ describe("basic functionality", () => {
     });
 
     it("should convert values to specific types if they are set via @Type decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -607,7 +607,7 @@ describe("basic functionality", () => {
     });
 
     it("should transform nested objects too and make sure their decorators are used too", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
 
@@ -687,7 +687,7 @@ describe("basic functionality", () => {
     });
 
     it("should transform nested objects too and make sure given type is used instead of automatically guessed one", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
 
@@ -750,7 +750,7 @@ describe("basic functionality", () => {
     });
 
     it("should convert given plain object to class instance object", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
 
@@ -873,7 +873,7 @@ describe("basic functionality", () => {
     });
 
     it("should expose only properties that match given group", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
             id: number;
@@ -1141,7 +1141,7 @@ describe("basic functionality", () => {
     });
 
     it("should expose only properties that match given version", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
             id: number;
@@ -1381,7 +1381,7 @@ describe("basic functionality", () => {
     });
 
     it("should expose method and accessors that have @Expose()", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
             firstName: string;
@@ -1432,7 +1432,7 @@ describe("basic functionality", () => {
     });
 
     it("should expose with alternative name if its given", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -1487,7 +1487,7 @@ describe("basic functionality", () => {
     });
 
     it("should exclude all prefixed properties if prefix is given", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
             id: number;
@@ -1556,7 +1556,7 @@ describe("basic functionality", () => {
     });
 
     it("should be able to transform array too", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
 
         class User {

--- a/test/functional/circular-reference-problem.spec.ts
+++ b/test/functional/circular-reference-problem.spec.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 import {classToPlain, classToClass, plainToClass} from "../../src/index";
-import {defaultMetadataStorage} from "../../src/storage";
+import {getDefaultMetadataStorage} from "../../src/storage";
 import {TransformOperationExecutor} from "../../src/TransformOperationExecutor";
 import {assert} from "chai";
 import * as sinon from "sinon";
@@ -8,7 +8,7 @@ import * as sinon from "sinon";
 describe("circular reference problem", () => {
 
     it("should skip circular reference objects", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
             id: number;
@@ -57,7 +57,7 @@ describe("circular reference problem", () => {
     });
 
     it("should not skip circular reference objects, but handle it correctly in classToClass operation", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
             id: number;
@@ -125,12 +125,12 @@ describe("circular reference problem", () => {
         });
 
         it("enableCircularCheck option is undefined (default)", () => {
-            const result = plainToClass<User, Object>(User, user); 
+            const result = plainToClass<User, Object>(User, user);
             sinon.assert.notCalled(isCircularSpy);
         });
 
         it("enableCircularCheck option is true", () => {
-            const result = plainToClass<User, Object>(User, user, { enableCircularCheck: true }); 
+            const result = plainToClass<User, Object>(User, user, { enableCircularCheck: true });
             sinon.assert.called(isCircularSpy);
         });
     });

--- a/test/functional/custom-transform.spec.ts
+++ b/test/functional/custom-transform.spec.ts
@@ -1,13 +1,13 @@
 import "reflect-metadata";
 import {classToPlain, plainToClass} from "../../src/index";
-import {defaultMetadataStorage} from "../../src/storage";
+import {getDefaultMetadataStorage} from "../../src/storage";
 import {Exclude, Expose, Transform, Type} from "../../src/decorators";
 import * as moment from "moment";
 
 describe("custom transformation decorator", () => {
 
     it("@Expose decorator with \"name\" option should work with @Transform decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -25,7 +25,7 @@ describe("custom transformation decorator", () => {
     });
 
     it("@Transform decorator logic should be executed depend of toPlainOnly and toClassOnly set", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -67,7 +67,7 @@ describe("custom transformation decorator", () => {
     });
 
     it("versions and groups should work with @Transform decorator too", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 

--- a/test/functional/es6-data-types.spec.ts
+++ b/test/functional/es6-data-types.spec.ts
@@ -1,12 +1,12 @@
 import "reflect-metadata";
 import {classToPlain, plainToClass} from "../../src/index";
-import {defaultMetadataStorage} from "../../src/storage";
+import {getDefaultMetadataStorage} from "../../src/storage";
 import {Type} from "../../src/decorators";
 
 describe("es6 data types", () => {
 
     it("using Map", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
             id: number;
@@ -60,7 +60,7 @@ describe("es6 data types", () => {
     });
 
     it("using Set", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
             id: number;
@@ -114,7 +114,7 @@ describe("es6 data types", () => {
     });
 
     it("using Map with objects", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Weapon {
             constructor(public model: string,
@@ -204,7 +204,7 @@ describe("es6 data types", () => {
     });
 
     it("using Set with objects", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Weapon {
             constructor(public model: string,

--- a/test/functional/ignore-decorators.spec.ts
+++ b/test/functional/ignore-decorators.spec.ts
@@ -1,12 +1,12 @@
 import "reflect-metadata";
 import {classToPlain} from "../../src/index";
-import {defaultMetadataStorage} from "../../src/storage";
+import {getDefaultMetadataStorage} from "../../src/storage";
 import {Exclude, Expose} from "../../src/decorators";
 
 describe("ignoring specific decorators", () => {
 
     it("when ignoreDecorators is set to true it should ignore all decorators", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 

--- a/test/functional/serialization-deserialization.spec.ts
+++ b/test/functional/serialization-deserialization.spec.ts
@@ -1,12 +1,12 @@
 import "reflect-metadata";
 import {serialize, deserialize, deserializeArray} from "../../src/index";
-import {defaultMetadataStorage} from "../../src/storage";
+import {getDefaultMetadataStorage} from "../../src/storage";
 import {Exclude} from "../../src/decorators";
 
 describe("serialization and deserialization objects", () => {
 
     it("should perform serialization and deserialization properly", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
             firstName: string;

--- a/test/functional/specify-maps.spec.ts
+++ b/test/functional/specify-maps.spec.ts
@@ -6,14 +6,14 @@ import {
     plainToClassFromExist,
     classToClass, classToClassFromExist
 } from "../../src/index";
-import {defaultMetadataStorage} from "../../src/storage";
+import {getDefaultMetadataStorage} from "../../src/storage";
 import {Exclude, Expose, Type} from "../../src/decorators";
 import {expect} from "chai";
 
 describe("specifying target maps", () => {
 
     it("should convert instance of the given object to plain javascript object and should expose all properties since its a default behaviour", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
             id: number;
@@ -95,7 +95,7 @@ describe("specifying target maps", () => {
     });
 
     it("should exclude all objects marked with @Exclude() decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
             id: number;
@@ -174,7 +174,7 @@ describe("specifying target maps", () => {
     });
 
     it("should exclude all properties from object if whole class is marked with @Exclude() decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         @Exclude()
         class User {
@@ -239,7 +239,7 @@ describe("specifying target maps", () => {
     });
 
     it("should exclude all properties from object if whole class is marked with @Exclude() decorator, but include properties marked with @Expose() decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         @Exclude()
         class User {
@@ -323,7 +323,7 @@ describe("specifying target maps", () => {
     });
 
     it("should exclude all properties from object if its defined via transformation options, but include properties marked with @Expose() decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -406,7 +406,7 @@ describe("specifying target maps", () => {
     });
 
     it("should expose all properties from object if its defined via transformation options, but exclude properties marked with @Exclude() decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -484,7 +484,7 @@ describe("specifying target maps", () => {
     });
 
     it("should convert values to specific types if they are set via @Type decorator", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -607,7 +607,7 @@ describe("specifying target maps", () => {
     });
 
     it("should transform nested objects too and make sure their decorators are used too", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
 
@@ -687,7 +687,7 @@ describe("specifying target maps", () => {
     });
 
     it("should transform nested objects too and make sure given type is used instead of automatically guessed one", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
 
@@ -750,7 +750,7 @@ describe("specifying target maps", () => {
     });
 
     it("should convert given plain object to class instance object", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
 
@@ -873,7 +873,7 @@ describe("specifying target maps", () => {
     });
 
     it("should expose only properties that match given group", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
             id: number;
@@ -1141,7 +1141,7 @@ describe("specifying target maps", () => {
     });
 
     it("should expose only properties that match given version", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
             id: number;
@@ -1381,7 +1381,7 @@ describe("specifying target maps", () => {
     });
 
     it("should expose method and accessors that have @Expose()", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
             firstName: string;
@@ -1432,7 +1432,7 @@ describe("specifying target maps", () => {
     });
 
     it("should expose with alternative name if its given", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -1487,7 +1487,7 @@ describe("specifying target maps", () => {
     });
 
     it("should exclude all prefixed properties if prefix is given", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class Photo {
             id: number;
@@ -1556,7 +1556,7 @@ describe("specifying target maps", () => {
     });
 
     it("should be able to transform array too", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
 
         class User {

--- a/test/functional/transformation-option.spec.ts
+++ b/test/functional/transformation-option.spec.ts
@@ -6,14 +6,14 @@ import {
     plainToClassFromExist,
     classToClass, classToClassFromExist
 } from "../../src/index";
-import {defaultMetadataStorage} from "../../src/storage";
+import {getDefaultMetadataStorage} from "../../src/storage";
 import {Exclude, Expose, Type} from "../../src/decorators";
 import {expect} from "chai";
 
 describe("filtering by transformation option", () => {
 
     it("@Exclude with toPlainOnly set to true then it should be excluded only during classToPlain and classToPlainFromExist operations", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -54,7 +54,7 @@ describe("filtering by transformation option", () => {
     });
 
     it("@Exclude with toClassOnly set to true then it should be excluded only during plainToClass and plainToClassFromExist operations", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         class User {
 
@@ -95,7 +95,7 @@ describe("filtering by transformation option", () => {
     });
 
     it("@Expose with toClassOnly set to true then it should be excluded only during classToPlain and classToPlainFromExist operations", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         @Exclude()
         class User {
@@ -137,7 +137,7 @@ describe("filtering by transformation option", () => {
     });
 
     it("@Expose with toPlainOnly set to true then it should be excluded only during classToPlain and classToPlainFromExist operations", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         @Exclude()
         class User {

--- a/test/functional/transformer-method.spec.ts
+++ b/test/functional/transformer-method.spec.ts
@@ -1,12 +1,12 @@
 import "reflect-metadata";
-import {defaultMetadataStorage} from "../../src/storage";
+import {getDefaultMetadataStorage} from "../../src/storage";
 import {Exclude, Expose, TransformClassToPlain, TransformClassToClass} from "../../src/decorators";
 import {expect} from "chai";
 
 describe("transformer methods decorator", () => {
 
     it("should expose non configuration properties and return User instance class", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         @Exclude()
         class User {
@@ -23,7 +23,7 @@ describe("transformer methods decorator", () => {
         }
 
         class UserController {
-            
+
             @TransformClassToClass()
             getUser() {
                 const user = new User();
@@ -51,7 +51,7 @@ describe("transformer methods decorator", () => {
     });
 
     it("should expose non configuration properties", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         @Exclude()
         class User {
@@ -68,7 +68,7 @@ describe("transformer methods decorator", () => {
         }
 
         class UserController {
-            
+
             @TransformClassToPlain()
             getUser() {
                 const user = new User();
@@ -94,7 +94,7 @@ describe("transformer methods decorator", () => {
     });
 
     it("should expose non configuration properties and properties with specific groups", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         @Exclude()
         class User {
@@ -114,7 +114,7 @@ describe("transformer methods decorator", () => {
         }
 
         class UserController {
-            
+
             @TransformClassToPlain({ groups: ["user.permissions"] })
             getUserWithRoles() {
                 const user = new User();
@@ -143,7 +143,7 @@ describe("transformer methods decorator", () => {
     });
 
     it("should expose non configuration properties with specific version", () => {
-        defaultMetadataStorage.clear();
+        getDefaultMetadataStorage().clear();
 
         @Exclude()
         class User {
@@ -178,7 +178,7 @@ describe("transformer methods decorator", () => {
 
                 return user;
             }
-                    
+
             @TransformClassToPlain({ version: 2 })
             getUserVersion2() {
                 const user = new User();


### PR DESCRIPTION

Hi @pleerock 

Two main changes in this pull request: 

- like routing controllers, global storage is now part of global variable and can be retrieved from getDefaultMetadataStorage() in storage.ts
- Export MetadataStorage in public api so we can use it.


