### PR TITLE
Extend classToPlain functionality

### DIFF
--- a/src/ClassTransformer.ts
+++ b/src/ClassTransformer.ts
@@ -22,6 +22,17 @@ export class ClassTransformer {
     }
 
     /**
+     * Converts class (constructor) object with a type to plain (literal) object. Also works with arrays.
+     * Enables decorators to operate properly for conversions to plain objects
+     */
+    classToPlainWithType<T>(cls: ClassType<T>, object: T, options?: ClassTransformOptions): Object;
+    classToPlainWithType<T>(cls: ClassType<T>, object: T[], options?: ClassTransformOptions): Object[];
+    classToPlainWithType<T>(cls: ClassType<T>, object: T|T[], options?: ClassTransformOptions): Object|Object[] {
+        const executor = new TransformOperationExecutor(TransformationType.CLASS_TO_PLAIN, options || {});
+        return executor.transform(undefined, object, cls, undefined, undefined, undefined);
+    }
+
+    /**
      * Converts class (constructor) object to plain (literal) object.
      * Uses given plain object as source object (it means fills given plain object with data from class object).
      * Also works with arrays.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,16 @@ export function classToPlain<T>(object: T[], options?: ClassTransformOptions): O
 export function classToPlain<T>(object: T|T[], options?: ClassTransformOptions): Object|Object[] {
     return classTransformer.classToPlain(object, options);
 }
+/**
+ * Converts class (constructor) object with a type to plain (literal) object. Also works with arrays.
+ * Enables decorators to operate properly for conversions to plain objects
+ */
+export function classToPlainWithType<T>(cls: ClassType<T>, object: T, options?: ClassTransformOptions): Object;
+export function classToPlainWithType<T>(cls: ClassType<T>, object: T[], options?: ClassTransformOptions): Object[];
+export function classToPlainWithType<T>(cls: ClassType<T>, object: T|T[], options?: ClassTransformOptions): Object|Object[] {
+    return classTransformer.classToPlainWithType(cls, object, options);
+}
+
 
 /**
  * Converts class (constructor) object to plain (literal) object.


### PR DESCRIPTION
Add a way to pass the class type to the classToPlain method, ensuring that decorator metadata can be found at conversion time. 

Right now, `classToPlain` fails to find the metadata and so does not grab the excludes that it should.

Rather than attempting to resolve the target type in the `TransformOperationExecutor`, I have added some additional exported calls that allow a type to be passed in. This allows the metadata to be looked up and transformed.

This PR should close issues #105 and #95 