### PR TITLE
fix deserialize example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ You can deserialize your model to from a json using `deserialize` method:
 
 ```typescript
 import {deserialize} from "class-transformer";
-let photo = deserialize(photo);
+let photo = deserialize(Photo, photo);
 ```
 
 To make deserialization to work with arrays use `deserializeArray` method:
 
 ```typescript
 import {deserializeArray} from "class-transformer";
-let photos = deserializeArray(photos);
+let photos = deserializeArray(Photo, photos);
 ```
 
 ## Working with nested objects


### PR DESCRIPTION
Current example of `deserialize` is using invalid arguments for that function signature. It gives error when using. It needs the class also.

readme.md
```
#### deserialize and deserializeArray                                                                  

You can deserialize your model to from a json using `deserialize` method:

import {deserialize} from "class-transformer";
let photo = deserialize(photo);

To make deserialization to work with arrays use `deserializeArray` method:

import {deserializeArray} from "class-transformer";
let photos = deserializeArray(photos);
```

ClassTransformer.ts
```
    /**
     * Deserializes given JSON string to a object of the given class.
     */
    deserialize<T>(cls: ClassType<T>, json: string, options?: ClassTransformOptions): T {              
        const jsonObject: T = JSON.parse(json);
        return this.plainToClass(cls, jsonObject, options);
    }

    /**
     * Deserializes given JSON string to an array of objects of the given class.
     */
    deserializeArray<T>(cls: ClassType<T>, json: string, options?: ClassTransformOptions): T[] {
        const jsonObject: any[] = JSON.parse(json);
        return this.plainToClass(cls, jsonObject, options);
    }
```