### PR TITLE
Add deserialize callback feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "class-transformer",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4126,12 +4126,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -4158,6 +4152,12 @@
           }
         }
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -182,6 +182,10 @@ export class TransformOperationExecutor {
                 }
 
             }
+
+            if (newValue["onDeserialize"] !== undefined)
+                newValue["onDeserialize"]();
+
             return newValue;
 
         } else {

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -173,6 +173,33 @@ describe("basic functionality", () => {
         });
     });
 
+    it("should call onDeserialize method if defined", () => {
+        defaultMetadataStorage.clear();
+
+        let callCount: number = 0;
+
+        class Card {
+            public id: number;
+            public level: number;
+
+            onDeserialize()  { callCount++; }
+        }
+
+        class Deck {
+            @Type(() => Card)
+            public cards: Card[];
+        }
+
+        const jsCard: {} = { id: 1 };
+        const deck = { cards: [jsCard, jsCard ] };
+
+        const classInstanceDeck = plainToClass(Deck, deck);
+
+        callCount.should.be.equal(2, "the onDeserialize method was not called often enough (or too often)");
+        classInstanceDeck.cards.length.should.be.equal(2, "we didn't deserialize enough cards into the deck");
+
+    });
+
     it("should exclude all properties from object if whole class is marked with @Exclude() decorator", () => {
         defaultMetadataStorage.clear();
 


### PR DESCRIPTION
Added a deserialize callback function which allows one to do some sort of post processing.

Right now you just have to define a `onDeserialize` method and it will be executed by default. I need some help with the decorators so that it explicitly checks for a decorator which specifies the function name to be called.