### PR TITLE
Bug correction: some times arrayType is not an array neither an array-like object, is just an object

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -36,7 +36,7 @@ export class TransformOperationExecutor {
               level: number = 0) {
 
         if (value instanceof Array || value instanceof Set) {
-            const newValue = arrayType && this.transformationType === TransformationType.PLAIN_TO_CLASS ? new (arrayType as any)() : [];
+            let newValue = arrayType && this.transformationType === TransformationType.PLAIN_TO_CLASS ? new (arrayType as any)() : [];
             if (!(newValue instanceof Set) && !newValue.push) {
                 newValue = [];
             }

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -37,6 +37,10 @@ export class TransformOperationExecutor {
 
         if (value instanceof Array || value instanceof Set) {
             const newValue = arrayType && this.transformationType === TransformationType.PLAIN_TO_CLASS ? new (arrayType as any)() : [];
+            if (!(newValue instanceof Set) && !newValue.push) {
+                newValue = [];
+            }
+
             (value as any[]).forEach((subValue, index) => {
                 const subSource = source ? source[index] : undefined;
                 if (!this.options.enableCircularCheck || !this.isCircular(subValue, level)) {


### PR DESCRIPTION
The correction is associated to this issue:

https://github.com/typestack/class-transformer/issues/134