### PR TITLE
New CatchNotExposed decorator to do custom processing for extra attributes

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -99,7 +99,6 @@ export class TransformOperationExecutor {
 
             const catchNotExposedMetadata = defaultMetadataStorage.findCatchNotExposedMetadata(targetType);
             let catchNotExposedCallback = catchNotExposedMetadata ? catchNotExposedMetadata.propertyName : undefined;
-            console.log('catchNotExposedCallback ' + catchNotExposedCallback);
 
             // traverse over keys
             for (let key of keys) {
@@ -107,7 +106,6 @@ export class TransformOperationExecutor {
                 const triggerCatchNotExposedCallback = catchNotExposedCallback
                     ? undefined === defaultMetadataStorage.findExposeMetadata(targetType, key)
                     : false;
-                console.log('triggerCatchNotExposedCallback ' + triggerCatchNotExposedCallback);
                 let valueKey = key, newValueKey = key, propertyName = key;
                 if (!this.options.ignoreDecorators && targetType) {
                     if (this.transformationType === TransformationType.PLAIN_TO_CLASS) {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -7,6 +7,7 @@ import {ExcludeMetadata} from "./metadata/ExcludeMetadata";
 import {TransformMetadata} from "./metadata/TransformMetadata";
 import {ClassTransformOptions} from "./ClassTransformOptions";
 import {TransformationType} from "./TransformOperationExecutor";
+import {CatchNotExposedMetadata} from "./metadata/CatchNotExposedMetadata";
 
 /**
  * Defines a custom logic for value transformation.
@@ -50,6 +51,13 @@ export function Exclude(options?: ExcludeOptions) {
     return function(object: Object|Function, propertyName?: string) {
         const metadata = new ExcludeMetadata(object instanceof Function ? object : object.constructor, propertyName, options || {});
         defaultMetadataStorage.addExcludeMetadata(metadata);
+    };
+}
+
+export function CatchNotExposed() {
+    return function(target: any, key: string) {
+        const metadata = new CatchNotExposedMetadata(target.constructor, key);
+        defaultMetadataStorage.addCatchNotExposedMetadata(metadata);
     };
 }
 

--- a/src/metadata/CatchNotExposedMetadata.ts
+++ b/src/metadata/CatchNotExposedMetadata.ts
@@ -1,0 +1,9 @@
+import {TypeOptions} from "./ExposeExcludeOptions";
+
+export class CatchNotExposedMetadata {
+
+    constructor(public target: Function,
+                public propertyName: string) {
+    }
+
+}

--- a/src/metadata/MetadataStorage.ts
+++ b/src/metadata/MetadataStorage.ts
@@ -3,6 +3,7 @@ import {ExposeMetadata} from "./ExposeMetadata";
 import {ExcludeMetadata} from "./ExcludeMetadata";
 import {TransformationType} from "../TransformOperationExecutor";
 import {TransformMetadata} from "./TransformMetadata";
+import {CatchNotExposedMetadata} from "./CatchNotExposedMetadata";
 
 /**
  * Storage all library metadata.
@@ -17,6 +18,7 @@ export class MetadataStorage {
     private _transformMetadatas: TransformMetadata[] = [];
     private _exposeMetadatas: ExposeMetadata[] = [];
     private _excludeMetadatas: ExcludeMetadata[] = [];
+    private _catchNotExposedMetadatas: CatchNotExposedMetadata[] = [];
 
     // -------------------------------------------------------------------------
     // Adder Methods
@@ -36,6 +38,10 @@ export class MetadataStorage {
 
     addExcludeMetadata(metadata: ExcludeMetadata) {
         this._excludeMetadatas.push(metadata);
+    }
+
+    addCatchNotExposedMetadata(metadata: CatchNotExposedMetadata) {
+        this._catchNotExposedMetadatas.push(metadata);
     }
 
     // -------------------------------------------------------------------------
@@ -77,6 +83,10 @@ export class MetadataStorage {
 
     findTypeMetadata(target: Function, propertyName: string) {
         return this.findMetadata(this._typeMetadatas, target, propertyName);
+    }
+
+    findCatchNotExposedMetadata(target: Function) {
+        return this.getMetadata(this._catchNotExposedMetadatas, target)[0];
     }
 
     getStrategy(target: Function): "excludeAll"|"exposeAll"|"none" {


### PR DESCRIPTION
I implemented a feature to do custom processing for attributes not have @Expose decorator.
Example:
```
// plain object
{
  "name": "test",
  "extra1": 1
}

export class Test {
  @Expose()
  name: string;

  extraAttributes: object;

  // new decorator introduced
  @CatchNotExposed()
  public catchNotExposed(propertyName: string, value: any) {
    // can do any custom logic with all extra attributes
    this.extraAttributes[propertyName] = value;
  }

}

// plainToClass result
{
  "name": "test",
  "extraAttributes": {
    "extra1": 1
  }
}
```

This is suitable for allowing to automatically store extra attributes in database in JSON column, while basic attributes will go to specified columns.

If you think this feature is out of project's scope - can you please suggest how to do this in other way? I would like to use class-transformer's decorators to know which attributes is extra and which is core.