### PR TITLE
Fix circular checks breaking nested serialized types #128

### DIFF
--- a/test/functional/circular-reference-problem.spec.ts
+++ b/test/functional/circular-reference-problem.spec.ts
@@ -7,19 +7,26 @@ import * as sinon from "sinon";
 
 describe("circular reference problem", () => {
 
-    it("should skip circular reference objects", () => {
+    it("should skip circular reference objects in classToPlain operation", () => {
         defaultMetadataStorage.clear();
+
+        class Caption {
+            text: string;
+        }
 
         class Photo {
             id: number;
             filename: string;
             user: User;
             users: User[];
+
+            caption: Caption;
         }
 
         class User {
             id: number;
             firstName: string;
+            caption: Caption;
             photos: Photo[];
         }
 
@@ -31,7 +38,11 @@ describe("circular reference problem", () => {
         photo2.id = 2;
         photo2.filename = "she.jpg";
 
+        const caption = new Caption();
+        caption.text = "cool photo";
+
         const user = new User();
+        user.caption = caption;
         user.firstName = "Umed Khudoiberdiev";
         user.photos = [photo1, photo2];
 
@@ -40,17 +51,23 @@ describe("circular reference problem", () => {
         photo1.users = [user];
         photo2.users = [user];
 
+        photo1.caption = caption;
+        photo2.caption = caption;
+
         const plainUser = classToPlain(user, { enableCircularCheck: true });
         plainUser.should.be.eql({
             firstName: "Umed Khudoiberdiev",
+            caption: { text: "cool photo" },
             photos: [{
                 id: 1,
                 filename: "me.jpg",
-                users: []
+                users: [],
+                caption: { text: "cool photo" }
             }, {
                 id: 2,
                 filename: "she.jpg",
-                users: []
+                users: [],
+                caption: { text: "cool photo" }
             }]
         });
 


### PR DESCRIPTION
Fixes #128 and additionally the case added to the test as part of this PR.

The library currently detects circular references using a map keeping track of nesting level and disallowing equal references on lower nesting levels (see `transformedTypesMap`).

I fail to understand why this is necessary. Given transformation is a depth-first traversal of the object graph, my understanding is that a simple add/delete from a stack/`Set` should suffice. Please let me know if I'm missing something.

Aside - unsure why Travis CI is failing on only one of the node versions. I would appreciate some help with that failure.