### PR TITLE
replaced instanceof Array with Array.isArray

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -35,7 +35,7 @@ export class TransformOperationExecutor {
               isMap: boolean,
               level: number = 0) {
 
-        if (value instanceof Array || value instanceof Set) {
+        if (Array.isArray(value) || value instanceof Set) {
             const newValue = arrayType && this.transformationType === TransformationType.PLAIN_TO_CLASS ? new (arrayType as any)() : [];
             (value as any[]).forEach((subValue, index) => {
                 const subSource = source ? source[index] : undefined;
@@ -145,7 +145,7 @@ export class TransformOperationExecutor {
                 }
 
                 // if value is an array try to get its custom array type
-                const arrayType = value[valueKey] instanceof Array ? this.getReflectedType(targetType, propertyName) : undefined;
+                const arrayType = Array.isArray(value[valueKey]) ? this.getReflectedType(targetType, propertyName) : undefined;
                 // const subValueKey = TransformationType === TransformationType.PLAIN_TO_CLASS && newKeyName ? newKeyName : key;
                 const subSource = source ? source[valueKey] : undefined;
 


### PR DESCRIPTION
Hello,

I have run into a very sticky issue when testing our code that uses `class-transformer`. The short version is that Jest uses its own version of `Array` in order to sandbox the unit tests. As a result, it makes instanceof checks unreliable, and is preventing me from running certain tests.

I understand this isn't an issue with `class-transformer`, but changing to `Array.isArray` will make the code more robust for users testing using Jest, and any other situations with multiple globals.

See here for details on `isArray`: http://web.mit.edu/jwalden/www/isArray.html