### PR TITLE
add Factory and Identifier decorators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "class-transformer",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ClassTransformOptions.ts
+++ b/src/ClassTransformOptions.ts
@@ -21,6 +21,11 @@ export interface TargetMap {
 export interface ClassTransformOptions {
 
     /**
+     * Context is passed into factory on serialization
+     */
+    context?: any;
+
+    /**
      * Exclusion strategy. By default exposeAll is used, which means that it will expose all properties are transformed
      * by default.
      */

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -7,6 +7,8 @@ import {ExcludeMetadata} from "./metadata/ExcludeMetadata";
 import {TransformMetadata} from "./metadata/TransformMetadata";
 import {ClassTransformOptions} from "./ClassTransformOptions";
 import {TransformationType} from "./TransformOperationExecutor";
+import { IdentifierMetadata } from "./metadata/IdentifierMetadata";
+import { FactoryMetadata } from "./metadata/FactoryMetadata";
 
 /**
  * Defines a custom logic for value transformation.
@@ -26,6 +28,20 @@ export function Type(typeFunction?: (type?: TypeOptions) => Function) {
         const type = (Reflect as any).getMetadata("design:type", target, key);
         const metadata = new TypeMetadata(target.constructor, key, type, typeFunction);
         defaultMetadataStorage.addTypeMetadata(metadata);
+    };
+}
+
+export function Identifier() {
+    return function(object: Object|Function, propertyName?: string) {
+        const metadata = new IdentifierMetadata(object instanceof Function ? object : object.constructor, propertyName);
+        defaultMetadataStorage.addIdentifierMetadata(metadata);
+    };
+}
+
+export function Factory() {
+    return function(object: Object|Function, propertyName?: string) {
+        const metadata = new FactoryMetadata(object instanceof Function ? object : object.constructor, propertyName);
+        defaultMetadataStorage.addFactoryMetadata(metadata);
     };
 }
 

--- a/src/metadata/FactoryMetadata.ts
+++ b/src/metadata/FactoryMetadata.ts
@@ -1,0 +1,7 @@
+export class FactoryMetadata {
+
+    constructor(public target: Function,
+                public propertyName: string) {
+    }
+
+}

--- a/src/metadata/IdentifierMetadata.ts
+++ b/src/metadata/IdentifierMetadata.ts
@@ -1,0 +1,5 @@
+export class IdentifierMetadata {
+    constructor(public target: Function,
+                public propertyName: string) {
+    }
+}

--- a/src/metadata/MetadataStorage.ts
+++ b/src/metadata/MetadataStorage.ts
@@ -3,7 +3,8 @@ import {ExposeMetadata} from "./ExposeMetadata";
 import {ExcludeMetadata} from "./ExcludeMetadata";
 import {TransformationType} from "../TransformOperationExecutor";
 import {TransformMetadata} from "./TransformMetadata";
-
+import {FactoryMetadata} from "./FactoryMetadata";
+import {IdentifierMetadata} from "./IdentifierMetadata";
 /**
  * Storage all library metadata.
  */
@@ -17,10 +18,19 @@ export class MetadataStorage {
     private _transformMetadatas: TransformMetadata[] = [];
     private _exposeMetadatas: ExposeMetadata[] = [];
     private _excludeMetadatas: ExcludeMetadata[] = [];
-
+    private _factoryMetadatas: FactoryMetadata[] = [];
+    private _identifierMetadatas: IdentifierMetadata[] = [];
     // -------------------------------------------------------------------------
     // Adder Methods
     // -------------------------------------------------------------------------
+
+    addFactoryMetadata(metadata: FactoryMetadata) {
+        this._factoryMetadatas.push(metadata);
+    }
+
+    addIdentifierMetadata(metadata: IdentifierMetadata) {
+        this._identifierMetadatas.push(metadata);
+    }
 
     addTypeMetadata(metadata: TypeMetadata) {
         this._typeMetadatas.push(metadata);
@@ -84,6 +94,14 @@ export class MetadataStorage {
         const expose = this._exposeMetadatas.find(metadata => metadata.target === target && metadata.propertyName === undefined);
         if ((exclude && expose) || (!exclude && !expose)) return "none";
         return exclude ? "excludeAll" : "exposeAll";
+    }
+
+    getIdentifierMetadatas(target: Function): IdentifierMetadata[] {
+        return this.getMetadata(this._identifierMetadatas, target);
+    }
+
+    getFactoryMetadatas(target: Function): FactoryMetadata[] {
+        return this.getMetadata(this._factoryMetadatas, target);
     }
 
     getExposedMetadatas(target: Function): ExposeMetadata[] {

--- a/test/functional/factory-visited.spec.ts
+++ b/test/functional/factory-visited.spec.ts
@@ -1,0 +1,88 @@
+import "reflect-metadata";
+import {classToPlain, plainToClass} from "../../src/index";
+import {defaultMetadataStorage} from "../../src/storage";
+import {Type, Identifier, Factory} from "../../src/decorators";
+
+
+
+describe("es6 data types", () => {
+
+    it("only identifiers should be serialized when the same instance is to be serialized multiple times", () => {
+        class User {
+            @Identifier()
+            id: number;
+
+            @Identifier()
+            name: string;
+
+            nickName: string;
+
+            @Type(() => User)
+            followers: User[] = [];
+        }
+
+        const u2 = new User();
+        u2.id = 2;
+        u2.name = "scott";
+        u2.nickName = "scotty";
+
+        const u1 = new User();
+        u1.id = 1;
+        u1.name = "jeff";
+        u1.nickName = "jeffy";
+        u1.followers = [u1, u2];
+        const plain = classToPlain(u1);
+        plain.should.eql({
+            id: 1,
+            name: "jeff",
+            nickName: "jeffy",
+            followers: [{
+                id: 1,
+                name: "jeff"
+            }, {
+                id: 2,
+                name: "scott",
+                nickName: "scotty",
+                followers: []
+            }]
+        });
+    });
+
+    it("using factory", () => {
+      class User {
+          @Identifier()
+          id: number;
+
+          name: string;
+          @Type(() => User)
+          followers: User[] = [];
+
+          @Factory()
+          static factory(json: any, ctx: any) {
+              if (!ctx.users) { ctx.users = {}; }
+              if (!ctx.users[json.id]) {
+                  ctx.users[json.id] = new User();
+              }
+              return ctx.users[json.id];
+          }
+      }
+
+      const u = new User();
+      u.id = 1;
+      u.name = "meow";
+      const u2 = new User();
+      u2.id = 2;
+      u.followers.push(u);
+
+      const plain = classToPlain(u);
+      plain.should.eql({
+          id: 1,
+          name: "meow",
+          followers: [{id: 1}]
+      });
+      const context = {};
+      const yay = plainToClass(User, plain, {context});
+      
+      yay.should.be.eql(yay.followers[0]);
+    });
+});


### PR DESCRIPTION
I'm not sure if this is functionality you are interested in adding to this library.  I forked for a personal project to solve the following problem:

In my app I want to be able to generate classes with circular references and also serialize classes with circular references.

```javascript
const data = {
   user: {
      id: 1,
      name: "jim",
      followers: [{
          id: 1,
          name: "jim"
      }]   
}
```
With the above data, the single user "jim", only has one follower who is himself.  I'd like transform this data into a User class such that user.followers[0] === user is true.

I did this by adding a Factory decorator that can be used like so:
```javascript
      class User {
          @Identifier()
          id: number;

          name: string;
          @Type(() => User)
          followers: User[] = [];

          @Factory()
          static factory(userJson: any, context: any) {
              if (!context.users[userJson.id]) {
                  context.users[userJson.id] = new User();
              }
              return context.users[userJson.id]; //always return the same user instance associated with a given id
          }
      }

     const contest = {users: {}};
     const user = plainToClass(User, data.user, {context});
     console.log(user.followers[0] === user)// true
```

Then when serializing data with circular references, if I am not serializing an instance for the first time, I only serialize Identifier attributes

```javascript
     const plain = classToPlain(user);
     console.log(plain); /*

{
      id: 1,
      name: "jim",
      followers: [{
          id: 1
      }]   
}


*/
```


