### PR TITLE
Improve behavior around external errors

### DIFF
--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -9,6 +9,7 @@ import {
 import {defaultMetadataStorage} from "../../src/storage";
 import {Exclude, Expose, Type} from "../../src/decorators";
 import {expect} from "chai";
+import { TRANSFORMATION_ERROR_PREFIX } from "../../src/TransformOperationExecutor";
 
 describe("basic functionality", () => {
 
@@ -1738,4 +1739,115 @@ describe("basic functionality", () => {
         transformedClass.should.be.instanceOf(TestClass);
     });
 
+    it("should catch errors thrown by target class constructors and source object functions, and throw a formatted error to aid troubleshooting", () => {
+        defaultMetadataStorage.clear();
+
+        class Photo {
+
+            id: number;
+
+            name: string;
+
+            @Exclude()
+            filename: string;
+
+            metadata: string;
+
+            uploadDate: Date;
+
+            constructor(id: number) {
+                if (typeof id !== "number") {
+                    throw new Error("Photo#constructor - requires a numeric ID in constructor.");
+                }
+            }
+        }
+
+        class User {
+
+            id: number;
+
+            firstName: string;
+
+            lastName: string;
+
+            @Exclude()
+            password: string;
+
+            @Type(type => Photo)
+            photo: Photo;
+
+            // contrived example of a class with a problematic function exposed.
+            @Expose()
+            getName(separator: string): string {
+                if (undefined === separator) {
+                    throw new Error("User#getName - missing required parameter");
+                }
+                return this.firstName + `${separator}` + this.lastName;
+            }
+        }
+
+        const user = new User();
+        user.firstName = "Umed";
+        user.lastName = "Khudoiberdiev";
+        user.password = "imnosuperman";
+        user.photo = new Photo(1);
+        user.photo.name = "Me";
+        user.photo.filename = "iam.jpg";
+        user.photo.uploadDate = new Date();
+
+        const fromPlainUser = {
+            firstName: "Umed",
+            lastName: "Khudoiberdiev",
+            password: "imnosuperman",
+            photo: {
+                id: 1,
+                name: "Me",
+                filename: "iam.jpg",
+                uploadDate: new Date(),
+            }
+        };
+
+        const fromExistUser = new User();
+        fromExistUser.id = 1;
+        const fromExistPhoto = new Photo(1);
+        fromExistPhoto.metadata = "taken by Camera";
+        fromExistUser.photo = fromExistPhoto;
+
+        try {
+            plainToClass(User, fromPlainUser);
+        } catch (e) {
+            e.should.be.instanceOf(Error);
+            (e as Error).message.indexOf(TRANSFORMATION_ERROR_PREFIX).should.not.be.eql(-1);
+            // Not sure this is the best way to do these tests, open to suggestions.
+        }
+
+        try {
+            plainToClassFromExist(fromExistUser, fromPlainUser);
+        } catch (e) {
+            e.should.be.instanceOf(Error);
+            (e as Error).message.indexOf(TRANSFORMATION_ERROR_PREFIX).should.not.be.eql(-1);
+        }
+
+        try {
+            classToClass(user);
+        } catch (e) {
+            e.should.be.instanceOf(Error);
+            (e as Error).message.indexOf(TRANSFORMATION_ERROR_PREFIX).should.not.be.eql(-1);
+        }
+
+        try {
+            classToClassFromExist(user, fromExistUser);
+        } catch (e) {
+            e.should.be.instanceOf(Error);
+            (e as Error).message.indexOf(TRANSFORMATION_ERROR_PREFIX).should.not.be.eql(-1);
+        }
+
+        try {
+            classToPlain(user);
+        } catch (e) {
+            e.should.be.instanceOf(Error);
+            (e as Error).message.indexOf(TRANSFORMATION_ERROR_PREFIX).should.not.be.eql(-1);
+        }
+
+    });
 });


### PR DESCRIPTION
See my comments on this issue for additional contex: https://github.com/typestack/class-transformer/issues/174

Here's my attempt at improving the way errors thrown by external code are handled.  I believe class-transformer should not attempt to suppress the errors that get thrown, but because of the metadata it records, it's in a privileged position to provide valuable error logging when a problem is encountered, so it seems like a waste to not log something.

I've added some tests, but they probably aren't that great.  They end up printing errors to the console, which is exactly what I'd want to happen when I'm using the library and something goes wrong, but is pretty disruptive when running tests to validate a change to this repository.

I'm open to suggestions on how to make this better, the repo doesn't really have a precedent for error handling or logging, and this PR may end up setting that precedent if it's merged.

The biggest point I'm unsure of is whether we should throw a new error (like I currently am), or just log our custom info and re-throw the error we caught.  I think re-throwing the original error is probably more transparent for any projects that already depend on this and might have some error-based control flow in place already, but throwing our own error doesn't necessarily break those use cases, and gives more valuable information in the error that surfaces in the users code.

I also think there would be some wisdom in adding a way to enable/disable the logging, so users can choose to suppress the console logs in production builds.  This could be added as a simple boolean option in `ClassTransformOptions`, but I think it would be better to control something like that with a global setting somehow, rather than needing to add a parameter to every single function call.  I don't think there's a mechanism in place for global settings like that, and it'd be a large addition, so I opted to leave it out for now.