### PR TITLE
Ensure array plains in union types default to arrays in class types

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -1,6 +1,6 @@
 import { ClassTransformOptions } from "./ClassTransformOptions";
 import { defaultMetadataStorage } from "./storage";
-import { TypeHelpOptions, Discriminator, TypeOptions } from "./metadata/ExposeExcludeOptions";
+import { TypeHelpOptions, TypeOptions } from "./metadata/ExposeExcludeOptions";
 import { TypeMetadata } from "./metadata/TypeMetadata";
 
 export enum TransformationType {
@@ -37,7 +37,7 @@ export class TransformOperationExecutor {
         level: number = 0) {
 
         if (Array.isArray(value) || value instanceof Set) {
-            const newValue = arrayType && this.transformationType === TransformationType.PLAIN_TO_CLASS ? new (arrayType as any)() : [];
+            const newValue = arrayType && this.transformationType === TransformationType.PLAIN_TO_CLASS ? instantiateArrayType(arrayType) : [];
             (value as any[]).forEach((subValue, index) => {
                 const subSource = source ? source[index] : undefined;
                 if (!this.options.enableCircularCheck || !this.isCircular(subValue)) {
@@ -401,4 +401,12 @@ export class TransformOperationExecutor {
         return this.options.groups.some(optionGroup => groups.indexOf(optionGroup) !== -1);
     }
 
+}
+
+function instantiateArrayType (arrayType: Function): Array<any> | Set<any> {
+    const array = new (arrayType as any)();
+    if (!(array instanceof Set) && !("push" in array)) {
+        return [];
+    }
+    return array;
 }

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -1738,4 +1738,33 @@ describe("basic functionality", () => {
         transformedClass.should.be.instanceOf(TestClass);
     });
 
+    it("should default union types where the plain type is an array to an array result", () => {
+        class User {
+            name: string;
+        }
+
+        class TestClass {
+            @Type(() => User)
+            usersDefined: User[] | undefined;
+
+            @Type(() => User)
+            usersUndefined: User[] | undefined;
+        }
+
+        const obj = Object.create(null);
+        obj.usersDefined = [{ name: "a-name" }];
+        obj.usersUndefined = undefined;
+
+        const transformedClass = plainToClass(TestClass, obj as Object);
+
+        transformedClass.should.be.instanceOf(TestClass);
+
+        transformedClass.usersDefined.should.be.instanceOf(Array);
+        transformedClass.usersDefined.length.should.equal(1);
+        transformedClass.usersDefined[0].should.be.instanceOf(User);
+        transformedClass.usersDefined[0].name.should.equal("a-name");
+
+        expect(transformedClass.usersUndefined).to.equal(undefined);
+    });
+
 });


### PR DESCRIPTION
Glad to see this library is being actively maintained again.

This is another fix we had on our fork.

It addresses the scenario when `plainToClass`ing an array for a property whose type which is declared as a union type e.g. `users: User[] | undefined`. In this case, class-transformer relied on `design:type`, which is `Object` for a union type and would cause the call to `push` to fail further below (essentially trying to map an array plain to a plain object).

The tests should be self-explanatory on the case this change covers.