### PR TITLE
Avoid trigger getter before test it

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -205,7 +205,7 @@ export class TransformOperationExecutor {
                 if (newValue.constructor.prototype) {
                     const descriptor = Object.getOwnPropertyDescriptor(newValue.constructor.prototype, newValueKey);
                     if ((this.transformationType === TransformationType.PLAIN_TO_CLASS || this.transformationType === TransformationType.CLASS_TO_CLASS)
-                        && (newValue[newValueKey] instanceof Function || (descriptor && !descriptor.set))) //  || TransformationType === TransformationType.CLASS_TO_CLASS
+                        && ((descriptor && !descriptor.set) || newValue[newValueKey] instanceof Function)) //  || TransformationType === TransformationType.CLASS_TO_CLASS
                         continue;
                 }
 


### PR DESCRIPTION
Currently it get property value to test if it is a function before test if it is a getter.
If it is a getter there, the getter will be called accidentally.

This patch changes the test order to avoid it.