### PR TITLE
fix: update the plainToClass array definitions.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export function classToPlainFromExist<T>(object: T, plainObject: Object|Object[]
 /**
  * Converts plain (literal) object to class (constructor) object. Also works with arrays.
  */
-export function plainToClass<T, V extends Array<any>>(cls: ClassType<T>, plain: V, options?: ClassTransformOptions): T[];
+export function plainToClass<T, V>(cls: ClassType<T>, plain: V[], options?: ClassTransformOptions): T[];
 export function plainToClass<T, V>(cls: ClassType<T>, plain: V, options?: ClassTransformOptions): T;
 export function plainToClass<T, V>(cls: ClassType<T>, plain: V|V[], options?: ClassTransformOptions): T|T[] {
     return classTransformer.plainToClass(cls, plain as any, options);
@@ -42,7 +42,7 @@ export function plainToClass<T, V>(cls: ClassType<T>, plain: V|V[], options?: Cl
  * Uses given object as source object (it means fills given object with data from plain object).
  *  Also works with arrays.
  */
-export function plainToClassFromExist<T, V extends Array<any>>(clsObject: T[], plain: V, options?: ClassTransformOptions): T[];
+export function plainToClassFromExist<T, V>(clsObject: T[], plain: V[], options?: ClassTransformOptions): T[];
 export function plainToClassFromExist<T, V>(clsObject: T, plain: V, options?: ClassTransformOptions): T;
 export function plainToClassFromExist<T, V>(clsObject: T, plain: V|V[], options?: ClassTransformOptions): T|T[] {
     return classTransformer.plainToClassFromExist(clsObject, plain, options);


### PR DESCRIPTION
I noticed that the original definition seemed to default to the array
form of the declaration.  From what I can tell, this small change will
choose the correct overload.

I see that the original change here is two years, old.  I don't know if
this is something that changed in a later version of TypeScript and
maybe that's why I'm running into this now.

Snippet:
```typescript
class Foo {}

const response = await fetch("https://httpbin.org/json");
const json = await response.json(); // has type `any`

// Previously had type Foo[], now has type Foo
const foo = plainToClass(Foo, json); 

// -----

class Foo {}

const response = await fetch("https://httpbin.org/json");
const json: any[] = await response.json(); // has type `any[]`

// Has type Foo[] before and after change.
const foo = plainToClass(Foo, json); 
```
