### PR TITLE
Add support for global include policy.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -169,6 +169,12 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
+    "arg": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -456,6 +462,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -5092,6 +5104,24 @@
         "urix": "^0.1.0"
       }
     },
+    "source-map-support": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -5469,6 +5499,27 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
+    },
+    "ts-node": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
+      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        }
+      }
     },
     "tslint": {
       "version": "4.5.1",
@@ -6039,6 +6090,12 @@
           "dev": true
         }
       }
+    },
+    "yn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
+      "integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "@types/moment": "^2.13.0",
     "@types/chai": "^3.4.34",
     "@types/es6-shim": "^0.31.32",
     "@types/mocha": "^2.2.33",
+    "@types/moment": "^2.13.0",
     "@types/node": "0.0.2",
     "@types/sinon": "^2.2.2",
     "chai": "^4.2.0",
@@ -54,6 +54,7 @@
     "remap-istanbul": "^0.7.0",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
+    "ts-node": "^8.3.0",
     "tslint": "^4.0.2",
     "tslint-stylish": "^2.1.0-beta",
     "typescript": "^2.0.10"

--- a/src/ClassTransformOptions.ts
+++ b/src/ClassTransformOptions.ts
@@ -2,6 +2,8 @@
  * Allows to specify a map of Types in the object without using @Type decorator.
  * This is useful when you have external classes.
  */
+import {Include} from "./Include";
+
 export interface TargetMap {
 
     /**
@@ -74,4 +76,12 @@ export interface ClassTransformOptions {
      * DEFAULT: `false`
      */
     enableImplicitConversion?: boolean;
+
+
+    /**
+     * Sets the global policy for which fields will be included. The default is any defined field.
+     */
+    includePolicy?: Include;
+
+
 }

--- a/src/Include.ts
+++ b/src/Include.ts
@@ -1,0 +1,10 @@
+export enum Include {
+    /**
+     * Include all defined properties.
+     */
+    DEFAULT = "DEFAULT",
+    /**
+     * Include all defined properties, except for null values.
+     */
+    NON_NULL = "NON_NULL"
+}

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -1,7 +1,8 @@
-import { ClassTransformOptions } from "./ClassTransformOptions";
-import { defaultMetadataStorage } from "./storage";
-import { TypeHelpOptions, TypeOptions } from "./metadata/ExposeExcludeOptions";
-import { TypeMetadata } from "./metadata/TypeMetadata";
+import {ClassTransformOptions} from "./ClassTransformOptions";
+import {defaultMetadataStorage} from "./storage";
+import {TypeHelpOptions, TypeOptions} from "./metadata/ExposeExcludeOptions";
+import {TypeMetadata} from "./metadata/TypeMetadata";
+import {Include} from "./Include";
 
 export enum TransformationType {
     PLAIN_TO_CLASS,
@@ -405,6 +406,9 @@ export class TransformOperationExecutor {
             return self.indexOf(key) === index;
         });
 
+        // apply include policy
+        keys = this.applyIncludePolicy(keys, object, this.options.includePolicy || Include.DEFAULT);
+
         return keys;
     }
 
@@ -425,6 +429,15 @@ export class TransformOperationExecutor {
         return this.options.groups.some(optionGroup => groups.indexOf(optionGroup) !== -1);
     }
 
+    private applyIncludePolicy(keys: string[], object: any, include: Include): string[] {
+        if (include === Include.DEFAULT) {
+            return keys;
+        } else if (include === Include.NON_NULL) {
+            return keys.filter((it: string) => object[it] !== null);
+        } else {
+            throw new Error(`Unsupported Include policy ${include}`);
+        }
+    }
 }
 
 function instantiateArrayType(arrayType: Function): Array<any> | Set<any> {

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -10,6 +10,7 @@ import { defaultMetadataStorage } from "../../src/storage";
 import { Exclude, Expose, Type } from "../../src/decorators";
 import { expect } from "chai";
 import { testForBuffer } from "../../src/TransformOperationExecutor";
+import {Include} from "../../src/Include";
 
 describe("basic functionality", () => {
 
@@ -1529,6 +1530,47 @@ describe("basic functionality", () => {
         likeUser.firstName = "Umed";
         likeUser.lastName = "Khudoiberdiev";
         transformedUser.should.be.eql(likeUser);
+
+    });
+
+    it("should not expose null if include policy is NON_NULL", () => {
+        defaultMetadataStorage.clear();
+
+        class Photo {
+            id: number;
+            filename: string;
+            status: number;
+        }
+
+        class User {
+
+
+            firstName: string;
+            lastName: string;
+            password: string;
+
+            @Type(type => Photo)
+            photos: Photo[];
+
+        }
+
+        const user = new User();
+        user.firstName = "Umed";
+        user.lastName = "Khudoiberdiev";
+        user.password = null;
+        const photo = new Photo();
+        photo.id = 1;
+        photo.filename = "myphoto.jpg";
+        photo.status = 1;
+        user.photos = [photo];
+
+        const plainUser1: any = classToPlain(user, {
+            includePolicy: Include.NON_NULL
+        });
+        plainUser1.should.not.be.instanceOf(User);
+        expect(plainUser1.firstName).to.eql("Umed");
+        expect(plainUser1.lastName).to.eql("Khudoiberdiev");
+        expect(plainUser1.password).to.be.undefined;
 
     });
 


### PR DESCRIPTION
We require the ability to exclude null fields, therefore 

Similar to the Jackson serializer for Java, add support for a global include policy: https://fasterxml.github.io/jackson-annotations/javadoc/2.7/com/fasterxml/jackson/annotation/JsonInclude.Include.html

Current possible values are: `[DEFAULT, NON_NULL]`

* Default includes all defined fields. 
* NON_NULL omits null fields. 



