### PR TITLE
Fixed link to changelog.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,4 +886,4 @@ usages.
 
 ## Release notes
 
-See information about breaking changes and release notes [here](https://github.com/pleerock/class-transformer/tree/master/doc/release-notes.md).
+See information about breaking changes and release notes [here](https://github.com/typestack/class-transformer/blob/master/CHANGELOG.md).


### PR DESCRIPTION
Previous changelog link was incorrect:
https://github.com/typestack/class-transformer/tree/master/doc/release-notes.md

Updating link to:
https://github.com/typestack/class-transformer/blob/master/CHANGELOG.md