### PR TITLE
fix: make transformers order deterministic

### DIFF
--- a/src/metadata/MetadataStorage.ts
+++ b/src/metadata/MetadataStorage.ts
@@ -215,7 +215,7 @@ export class MetadataStorage {
                 }
             }
         }
-        return (metadataFromAncestorsTarget).reverse().concat((metadataFromTarget || []).reverse());
+        return (metadataFromAncestorsTarget).slice().reverse().concat((metadataFromTarget || []).slice().reverse());
     }
 
     private getAncestors(target: Function): Function[] {

--- a/test/functional/transformer-order.spec.ts
+++ b/test/functional/transformer-order.spec.ts
@@ -1,0 +1,28 @@
+import "reflect-metadata";
+import { plainToClass } from "../../src/index";
+import { defaultMetadataStorage } from "../../src/storage";
+import { Expose, Transform } from "../../src/decorators";
+
+describe("applying several transformations", () => {
+  beforeEach(() => defaultMetadataStorage.clear());
+  afterEach(() => defaultMetadataStorage.clear());
+
+  it("should keep the order of the applied decorators after several plainToClass() calls", () => {
+    class User {
+      @Transform(() => "Jonathan")
+      @Transform(() => "John")
+      @Expose()
+      name: string;
+    }
+
+    const firstUser = plainToClass(User, { name: "Joe" });
+    expect(firstUser.name).toEqual("John");
+
+    // Prior to this pull request [#355](https://github.com/typestack/class-transformer/pull/355)
+    // the order of the transformations was reversed after every `plainToClass()` call
+    // So after consecutive calls `User#name` would be "John" - "Jonathan" - "John" - "Jonathan"...
+    // This test ensures the last transformation is always the last one to be applied
+    const secondUser = plainToClass(User, { name: "Joe" });
+    expect(secondUser.name).toEqual("John");
+  });
+});


### PR DESCRIPTION
When several trasnformers are applied at the same the order is reversed
every time plainToClass is called.

This fix make the trsnsfomers oders consistent across multiple `plainToClass()`
calls.

Fixes #231