### PR TITLE
Fix and merge pr 275

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
-      "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.3"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/core": {
@@ -37,73 +37,6 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -115,15 +48,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },
@@ -246,9 +170,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
-      "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true
     },
     "@babel/helpers": {
@@ -263,12 +187,12 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
-      "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.3",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -439,84 +363,6 @@
         "@babel/code-frame": "^7.10.4",
         "@babel/parser": "^7.10.4",
         "@babel/types": "^7.10.4"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "@babel/traverse": {
@@ -536,87 +382,11 @@
         "lodash": "^4.17.19"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-          "dev": true
-        },
-        "@babel/highlight": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
           "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },
@@ -629,14 +399,6 @@
         "@babel/helper-validator-identifier": "^7.10.4",
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-          "dev": true
-        }
       }
     },
     "@bcoe/v8-coverage": {
@@ -1239,14 +1001,6 @@
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
-        }
       }
     },
     "@typescript-eslint/experimental-utils": {
@@ -1295,14 +1049,6 @@
         "lodash": "^4.17.15",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
-        }
       }
     },
     "@typescript-eslint/visitor-keys": {
@@ -1875,15 +1621,6 @@
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.0"
           }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
         }
       }
     },
@@ -2379,12 +2116,6 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
         }
       }
     },
@@ -2423,12 +2154,6 @@
             "semver": "^7.3.2",
             "tsutils": "^3.17.1"
           }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
         }
       }
     },
@@ -3459,6 +3184,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-report": {
@@ -4438,12 +4171,6 @@
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
           }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
         }
       }
     },
@@ -4774,17 +4501,6 @@
             "supports-color": "^7.1.0"
           }
         },
-        "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
         "execa": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
@@ -4825,43 +4541,13 @@
           "requires": {
             "path-key": "^3.0.0"
           }
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
         }
       }
     },
     "listr2": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-2.4.0.tgz",
-      "integrity": "sha512-Hj2ECZdAxDkuYFtIKE35PgdMSqMp0muIhJRG5EyV5pOWFEUmKUG+fhfFrvIUNGBQvvi7wQ41eKTxDBisfvDjFQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-2.4.1.tgz",
+      "integrity": "sha512-8pYsCZCztr5+KAjReLyBeGhLV0vaQ2Du/eMe/ux9QAfQl7efiWejM1IWjALh0zHIRYuIbhQ8N2KztZ4ci56pnQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -4882,15 +4568,6 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
-          }
-        },
-        "rxjs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
-          "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
           }
         }
       }
@@ -4961,12 +4638,6 @@
           "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
           "dev": true
         },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4983,37 +4654,6 @@
             "astral-regex": "^2.0.0",
             "is-fullwidth-code-point": "^3.0.0"
           }
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
         }
       }
     },
@@ -5024,6 +4664,14 @@
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "make-error": {
@@ -5200,15 +4848,6 @@
         "shellwords": "^0.1.1",
         "uuid": "^8.2.0",
         "which": "^2.0.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "normalize-package-data": {
@@ -5408,9 +5047,9 @@
       }
     },
     "parse-json": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-      "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+      "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -5489,42 +5128,6 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        }
       }
     },
     "please-upgrade-node": {
@@ -5846,6 +5449,15 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
+    "rxjs": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
+      "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -6018,9 +5630,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
       "dev": true
     },
     "semver-compare": {
@@ -6671,12 +6283,6 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
       }

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -169,12 +169,16 @@ export class TransformOperationExecutor {
 
                 // get a subvalue
                 let subValue: any = undefined;
-                if (value instanceof Map) {
-                    subValue = value.get(valueKey);
-                } else if (value[valueKey] instanceof Function) {
-                    subValue = value[valueKey]();
-                } else {
+                if (this.transformationType === TransformationType.PLAIN_TO_CLASS) {
                     subValue = value[valueKey];
+                } else {
+                    if (value instanceof Map) {
+                        subValue = value.get(valueKey);
+                    } else if (value[valueKey] instanceof Function) {
+                        subValue = value[valueKey]();
+                    } else {
+                        subValue = value[valueKey];
+                    }
                 }
 
                 // determine a type

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -1445,6 +1445,35 @@ describe("basic functionality", () => {
 
     });
 
+    it("should set class as value in plainToClass", () => {
+        defaultMetadataStorage.clear();
+        class ClassValue {}
+
+        class User {
+          classValue: any;
+        }
+
+        const data = plainToClass(User, { classValue: ClassValue });
+        data.should.be.instanceOf(User);
+        data.classValue.should.be.eq(ClassValue);
+        const instance = new data.classValue();
+        instance.should.be.instanceOf(ClassValue);
+    });
+
+    it("should set function as value in plainToClass", () => {
+        defaultMetadataStorage.clear();
+        const testFunction = () => 10;
+
+        class User {
+            testFunction: Function;
+        }
+
+        const data = plainToClass(User, { testFunction });
+        data.should.be.instanceOf(User);
+        data.testFunction.should.be.eq(testFunction);
+        data.testFunction().should.be.eq(10);
+    });
+
     it("should expose method and accessors that have @Expose()", () => {
         defaultMetadataStorage.clear();
 

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -1,1823 +1,1823 @@
 import "reflect-metadata";
-import {classToClass, classToClassFromExist, classToPlain, classToPlainFromExist, plainToClass, plainToClassFromExist} from "../../src/index";
-import {defaultMetadataStorage} from "../../src/storage";
-import {Exclude, Expose, Type} from "../../src/decorators";
-import {testForBuffer} from "../../src/TransformOperationExecutor";
+import { classToClass, classToClassFromExist, classToPlain, classToPlainFromExist, plainToClass, plainToClassFromExist } from "../../src/index";
+import { defaultMetadataStorage } from "../../src/storage";
+import { Exclude, Expose, Type } from "../../src/decorators";
+import { testForBuffer } from "../../src/TransformOperationExecutor";
 
 describe("basic functionality", () => {
-    it("should return true if Buffer is present in environment, else false", () => {
-        expect(testForBuffer()).toBeTruthy();
-        const bufferImp = global.Buffer;
-        delete global.Buffer;
-        expect(testForBuffer()).toBeFalsy();
-        global.Buffer = bufferImp;
+  it("should return true if Buffer is present in environment, else false", () => {
+    expect(testForBuffer()).toBeTruthy();
+    const bufferImp = global.Buffer;
+    delete global.Buffer;
+    expect(testForBuffer()).toBeFalsy();
+    global.Buffer = bufferImp;
+  });
+
+  it("should convert instance of the given object to plain javascript object and should expose all properties since its a default behaviour", () => {
+    defaultMetadataStorage.clear();
+
+    class User {
+      id: number;
+      firstName: string;
+      lastName: string;
+      password: string;
+    }
+
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
+
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
+    };
+
+    const fromExistUser = new User();
+    fromExistUser.id = 1;
+
+    const plainUser = classToPlain(user);
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
     });
 
-    it("should convert instance of the given object to plain javascript object and should expose all properties since its a default behaviour", () => {
-        defaultMetadataStorage.clear();
+    const existUser = { id: 1, age: 27 };
+    const plainUser2 = classToPlainFromExist(user, existUser);
+    expect(plainUser2).not.toBeInstanceOf(User);
+    expect(plainUser2).toEqual({
+      id: 1,
+      age: 27,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
+    });
+    expect(plainUser2).toEqual(existUser);
 
-        class User {
-            id: number;
-            firstName: string;
-            lastName: string;
-            password: string;
-        }
-
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        };
-
-        const fromExistUser = new User();
-        fromExistUser.id = 1;
-
-        const plainUser = classToPlain(user);
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        });
-
-        const existUser = {id: 1, age: 27};
-        const plainUser2 = classToPlainFromExist(user, existUser);
-        expect(plainUser2).not.toBeInstanceOf(User);
-        expect(plainUser2).toEqual({
-            id: 1,
-            age: 27,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        });
-        expect(plainUser2).toEqual(existUser);
-
-        const transformedUser = plainToClass(User, fromPlainUser);
-        expect(transformedUser).toBeInstanceOf(User);
-        expect(transformedUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        });
-
-        const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
-        expect(fromExistTransformedUser).toBeInstanceOf(User);
-        expect(fromExistTransformedUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        });
-
-        const classToClassUser = classToClass(user);
-        expect(classToClassUser).toBeInstanceOf(User);
-        expect(classToClassUser).toEqual(user);
-        expect(classToClassUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        });
-
-        const classToClassFromExistUser = classToClassFromExist(user, fromExistUser);
-        expect(classToClassFromExistUser).toBeInstanceOf(User);
-        expect(classToClassFromExistUser).not.toEqual(user);
-        expect(classToClassFromExistUser).toEqual(fromExistUser);
-        expect(classToClassFromExistUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        });
+    const transformedUser = plainToClass(User, fromPlainUser);
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
     });
 
-    it("should exclude extraneous values if the excludeExtraneousValues option is set to true", () => {
-        defaultMetadataStorage.clear();
-
-        class User {
-            @Expose() id: number;
-            @Expose() firstName: string;
-            @Expose() lastName: string;
-        }
-
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            age: 12
-        };
-
-        const transformedUser = plainToClass(User, fromPlainUser);
-        expect(transformedUser).toBeInstanceOf(User);
-        expect(transformedUser).toHaveProperty("age");
-        expect(transformedUser.id).toBeUndefined();
-
-        const transformedUserWithoutExtra = plainToClass(User, fromPlainUser, {excludeExtraneousValues: true});
-        expect(transformedUserWithoutExtra).toBeInstanceOf(User);
-        expect(transformedUserWithoutExtra).not.toHaveProperty("age");
+    const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
+    expect(fromExistTransformedUser).toBeInstanceOf(User);
+    expect(fromExistTransformedUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
     });
 
-    it("should exclude all objects marked with @Exclude() decorator", () => {
-        defaultMetadataStorage.clear();
-
-        class User {
-            id: number;
-            firstName: string;
-            lastName: string;
-            @Exclude()
-            password: string;
-        }
-
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        };
-
-        const fromExistUser = new User();
-        fromExistUser.id = 1;
-
-        const plainUser: any = classToPlain(user);
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-        expect(plainUser.password).toBeUndefined();
-
-        const existUser = {id: 1, age: 27, password: "yayayaya"};
-        const plainUser2 = classToPlainFromExist(user, existUser);
-        expect(plainUser2).not.toBeInstanceOf(User);
-        expect(plainUser2).toEqual({
-            id: 1,
-            age: 27,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "yayayaya"
-        });
-        expect(plainUser2).toEqual(existUser);
-
-        const transformedUser = plainToClass(User, fromPlainUser);
-        expect(transformedUser).toBeInstanceOf(User);
-        expect(transformedUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-
-        const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
-        expect(fromExistTransformedUser).toBeInstanceOf(User);
-        expect(fromExistTransformedUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-
-        const classToClassUser = classToClass(user);
-        expect(classToClassUser).toBeInstanceOf(User);
-        expect(classToClassUser).not.toEqual(user);
-        expect(classToClassUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-
-        const classToClassFromExistUser = classToClassFromExist(user, fromExistUser);
-        expect(classToClassFromExistUser).toBeInstanceOf(User);
-        expect(classToClassFromExistUser).not.toEqual(user);
-        expect(classToClassFromExistUser).toEqual(fromExistUser);
-        expect(classToClassFromExistUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
+    const classToClassUser = classToClass(user);
+    expect(classToClassUser).toBeInstanceOf(User);
+    expect(classToClassUser).toEqual(user);
+    expect(classToClassUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
     });
 
-    it("should exclude all properties from object if whole class is marked with @Exclude() decorator", () => {
-        defaultMetadataStorage.clear();
+    const classToClassFromExistUser = classToClassFromExist(user, fromExistUser);
+    expect(classToClassFromExistUser).toBeInstanceOf(User);
+    expect(classToClassFromExistUser).not.toEqual(user);
+    expect(classToClassFromExistUser).toEqual(fromExistUser);
+    expect(classToClassFromExistUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
+    });
+  });
 
-        @Exclude()
-        class User {
-            id: number;
-            firstName: string;
-            lastName: string;
-            password: string;
-        }
+  it("should exclude extraneous values if the excludeExtraneousValues option is set to true", () => {
+    defaultMetadataStorage.clear();
 
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        };
+    class User {
+      @Expose() id: number;
+      @Expose() firstName: string;
+      @Expose() lastName: string;
+    }
 
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      age: 12
+    };
 
-        const fromExistUser = new User();
-        fromExistUser.id = 1;
+    const transformedUser = plainToClass(User, fromPlainUser);
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toHaveProperty("age");
+    expect(transformedUser.id).toBeUndefined();
 
-        const plainUser: any = classToPlain(user);
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({});
-        expect(plainUser.firstName).toBeUndefined();
-        expect(plainUser.lastName).toBeUndefined();
-        expect(plainUser.password).toBeUndefined();
+    const transformedUserWithoutExtra = plainToClass(User, fromPlainUser, { excludeExtraneousValues: true });
+    expect(transformedUserWithoutExtra).toBeInstanceOf(User);
+    expect(transformedUserWithoutExtra).not.toHaveProperty("age");
+  });
 
-        const existUser = {id: 1, age: 27};
-        const plainUser2 = classToPlainFromExist(user, existUser);
-        expect(plainUser2).not.toBeInstanceOf(User);
-        expect(plainUser2).toEqual({
-            id: 1,
-            age: 27
-        });
-        expect(plainUser2).toEqual(existUser);
+  it("should exclude all objects marked with @Exclude() decorator", () => {
+    defaultMetadataStorage.clear();
 
-        const transformedUser = plainToClass(User, fromPlainUser);
-        expect(transformedUser).toBeInstanceOf(User);
-        expect(transformedUser).toEqual({});
+    class User {
+      id: number;
+      firstName: string;
+      lastName: string;
+      @Exclude()
+      password: string;
+    }
 
-        const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
-        expect(fromExistTransformedUser).toBeInstanceOf(User);
-        expect(fromExistTransformedUser).toEqual({
-            id: 1
-        });
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
 
-        const classToClassUser = classToClass(user);
-        expect(classToClassUser).toBeInstanceOf(User);
-        expect(classToClassUser).not.toEqual(user);
-        expect(classToClassUser).toEqual({});
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
+    };
 
-        const classToClassFromExistUser = classToClassFromExist(user, fromExistUser);
-        expect(classToClassFromExistUser).toBeInstanceOf(User);
-        expect(classToClassFromExistUser).not.toEqual(user);
-        expect(classToClassFromExistUser).toEqual(fromExistUser);
-        expect(classToClassFromExistUser).toEqual({
-            id: 1
-        });
+    const fromExistUser = new User();
+    fromExistUser.id = 1;
+
+    const plainUser: any = classToPlain(user);
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
+    });
+    expect(plainUser.password).toBeUndefined();
+
+    const existUser = { id: 1, age: 27, password: "yayayaya" };
+    const plainUser2 = classToPlainFromExist(user, existUser);
+    expect(plainUser2).not.toBeInstanceOf(User);
+    expect(plainUser2).toEqual({
+      id: 1,
+      age: 27,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "yayayaya"
+    });
+    expect(plainUser2).toEqual(existUser);
+
+    const transformedUser = plainToClass(User, fromPlainUser);
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
     });
 
-    it("should exclude all properties from object if whole class is marked with @Exclude() decorator, but include properties marked with @Expose() decorator", () => {
-        defaultMetadataStorage.clear();
-
-        @Exclude()
-        class User {
-            id: number;
-
-            @Expose()
-            firstName: string;
-
-            @Expose()
-            lastName: string;
-
-            password: string;
-        }
-
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        };
-
-        const fromExistUser = new User();
-        fromExistUser.id = 1;
-
-        const plainUser: any = classToPlain(user);
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-        expect(plainUser.password).toBeUndefined();
-
-        const existUser = {id: 1, age: 27};
-        const plainUser2 = classToPlainFromExist(user, existUser);
-        expect(plainUser2).not.toBeInstanceOf(User);
-        expect(plainUser2).toEqual({
-            id: 1,
-            age: 27,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-        expect(plainUser2).toEqual(existUser);
-
-        const transformedUser = plainToClass(User, fromPlainUser);
-        expect(transformedUser).toBeInstanceOf(User);
-        expect(transformedUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-
-        const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
-        expect(fromExistTransformedUser).toBeInstanceOf(User);
-        expect(fromExistTransformedUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-
-        const classToClassUser = classToClass(user);
-        expect(classToClassUser).toBeInstanceOf(User);
-        expect(classToClassUser).not.toEqual(user);
-        expect(classToClassUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-
-        const classToClassFromExistUser = classToClassFromExist(user, fromExistUser);
-        expect(classToClassFromExistUser).toBeInstanceOf(User);
-        expect(classToClassFromExistUser).not.toEqual(user);
-        expect(classToClassFromExistUser).toEqual(fromExistUser);
-        expect(classToClassFromExistUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
+    const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
+    expect(fromExistTransformedUser).toBeInstanceOf(User);
+    expect(fromExistTransformedUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
     });
 
-    it("should exclude all properties from object if its defined via transformation options, but include properties marked with @Expose() decorator", () => {
-        defaultMetadataStorage.clear();
-
-        class User {
-            id: number;
-
-            @Expose()
-            firstName: string;
-
-            @Expose()
-            lastName: string;
-
-            password: string;
-        }
-
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        };
-
-        const fromExistUser = new User();
-        fromExistUser.id = 1;
-
-        const plainUser: any = classToPlain(user, {strategy: "excludeAll"});
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-        expect(plainUser.password).toBeUndefined();
-
-        const existUser = {id: 1, age: 27};
-        const plainUser2 = classToPlainFromExist(user, existUser, {strategy: "excludeAll"});
-        expect(plainUser2).not.toBeInstanceOf(User);
-        expect(plainUser2).toEqual({
-            id: 1,
-            age: 27,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-        expect(plainUser2).toEqual(existUser);
-
-        const transformedUser = plainToClass(User, fromPlainUser, {strategy: "excludeAll"});
-        expect(transformedUser).toBeInstanceOf(User);
-        expect(transformedUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-
-        const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser, {strategy: "excludeAll"});
-        expect(fromExistTransformedUser).toBeInstanceOf(User);
-        expect(fromExistTransformedUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-
-        const classToClassUser = classToClass(user, {strategy: "excludeAll"});
-        expect(classToClassUser).toBeInstanceOf(User);
-        expect(classToClassUser).not.toEqual(user);
-        expect(classToClassUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
-
-        const classToClassFromExistUser = classToClassFromExist(user, fromExistUser, {strategy: "excludeAll"});
-        expect(classToClassFromExistUser).toBeInstanceOf(User);
-        expect(classToClassFromExistUser).not.toEqual(user);
-        expect(classToClassFromExistUser).toEqual(fromExistUser);
-        expect(classToClassFromExistUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev"
-        });
+    const classToClassUser = classToClass(user);
+    expect(classToClassUser).toBeInstanceOf(User);
+    expect(classToClassUser).not.toEqual(user);
+    expect(classToClassUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
     });
 
-    it("should expose all properties from object if its defined via transformation options, but exclude properties marked with @Exclude() decorator", () => {
-        defaultMetadataStorage.clear();
+    const classToClassFromExistUser = classToClassFromExist(user, fromExistUser);
+    expect(classToClassFromExistUser).toBeInstanceOf(User);
+    expect(classToClassFromExistUser).not.toEqual(user);
+    expect(classToClassFromExistUser).toEqual(fromExistUser);
+    expect(classToClassFromExistUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
+    });
+  });
 
-        class User {
-            id: number;
-            firstName: string;
+  it("should exclude all properties from object if whole class is marked with @Exclude() decorator", () => {
+    defaultMetadataStorage.clear();
 
-            @Exclude()
-            lastName: string;
+    @Exclude()
+    class User {
+      id: number;
+      firstName: string;
+      lastName: string;
+      password: string;
+    }
 
-            @Exclude()
-            password: string;
-        }
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
+    };
 
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
 
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        };
+    const fromExistUser = new User();
+    fromExistUser.id = 1;
 
-        const fromExistUser = new User();
-        fromExistUser.id = 1;
+    const plainUser: any = classToPlain(user);
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({});
+    expect(plainUser.firstName).toBeUndefined();
+    expect(plainUser.lastName).toBeUndefined();
+    expect(plainUser.password).toBeUndefined();
 
-        const plainUser: any = classToPlain(user, {strategy: "exposeAll"});
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({
-            firstName: "Umed"
-        });
-        expect(plainUser.lastName).toBeUndefined();
-        expect(plainUser.password).toBeUndefined();
+    const existUser = { id: 1, age: 27 };
+    const plainUser2 = classToPlainFromExist(user, existUser);
+    expect(plainUser2).not.toBeInstanceOf(User);
+    expect(plainUser2).toEqual({
+      id: 1,
+      age: 27
+    });
+    expect(plainUser2).toEqual(existUser);
 
-        const existUser = {id: 1, age: 27};
-        const plainUser2 = classToPlainFromExist(user, existUser, {strategy: "exposeAll"});
-        expect(plainUser2).not.toBeInstanceOf(User);
-        expect(plainUser2).toEqual({
-            id: 1,
-            age: 27,
-            firstName: "Umed"
-        });
-        expect(plainUser2).toEqual(existUser);
+    const transformedUser = plainToClass(User, fromPlainUser);
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toEqual({});
 
-        const transformedUser = plainToClass(User, fromPlainUser, {strategy: "exposeAll"});
-        expect(transformedUser).toBeInstanceOf(User);
-        expect(transformedUser).toEqual({
-            firstName: "Umed"
-        });
-
-        const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser, {strategy: "exposeAll"});
-        expect(fromExistTransformedUser).toBeInstanceOf(User);
-        expect(fromExistTransformedUser).toEqual({
-            id: 1,
-            firstName: "Umed"
-        });
-
-        const classToClassUser = classToClass(user, {strategy: "exposeAll"});
-        expect(classToClassUser).toBeInstanceOf(User);
-        expect(classToClassUser).not.toEqual(user);
-        expect(classToClassUser).toEqual({
-            firstName: "Umed"
-        });
-
-        const classToClassFromExistUser = classToClassFromExist(user, fromExistUser, {strategy: "exposeAll"});
-        expect(classToClassFromExistUser).toBeInstanceOf(User);
-        expect(classToClassFromExistUser).not.toEqual(user);
-        expect(classToClassFromExistUser).toEqual(fromExistUser);
-        expect(classToClassFromExistUser).toEqual({
-            id: 1,
-            firstName: "Umed"
-        });
+    const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
+    expect(fromExistTransformedUser).toBeInstanceOf(User);
+    expect(fromExistTransformedUser).toEqual({
+      id: 1
     });
 
-    it("should convert values to specific types if they are set via @Type decorator", () => {
-        defaultMetadataStorage.clear();
+    const classToClassUser = classToClass(user);
+    expect(classToClassUser).toBeInstanceOf(User);
+    expect(classToClassUser).not.toEqual(user);
+    expect(classToClassUser).toEqual({});
 
-        class User {
-            id: number;
+    const classToClassFromExistUser = classToClassFromExist(user, fromExistUser);
+    expect(classToClassFromExistUser).toBeInstanceOf(User);
+    expect(classToClassFromExistUser).not.toEqual(user);
+    expect(classToClassFromExistUser).toEqual(fromExistUser);
+    expect(classToClassFromExistUser).toEqual({
+      id: 1
+    });
+  });
 
-            @Type(type => String)
-            firstName: string;
+  it("should exclude all properties from object if whole class is marked with @Exclude() decorator, but include properties marked with @Expose() decorator", () => {
+    defaultMetadataStorage.clear();
 
-            @Type(type => String)
-            lastName: string;
+    @Exclude()
+    class User {
+      id: number;
 
-            @Type(type => Number)
-            password: number;
+      @Expose()
+      firstName: string;
 
-            @Type(type => Boolean)
-            isActive: boolean;
+      @Expose()
+      lastName: string;
 
-            @Type(type => Date)
-            registrationDate: Date;
+      password: string;
+    }
 
-            @Type(type => String)
-            lastVisitDate: string;
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
 
-            @Type(type => Buffer)
-            uuidBuffer: Buffer;
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
+    };
 
-            @Type(type => String)
-            nullableString?: null | string;
+    const fromExistUser = new User();
+    fromExistUser.id = 1;
 
-            @Type(type => Number)
-            nullableNumber?: null | number;
+    const plainUser: any = classToPlain(user);
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
+    });
+    expect(plainUser.password).toBeUndefined();
 
-            @Type(type => Boolean)
-            nullableBoolean?: null | boolean;
+    const existUser = { id: 1, age: 27 };
+    const plainUser2 = classToPlainFromExist(user, existUser);
+    expect(plainUser2).not.toBeInstanceOf(User);
+    expect(plainUser2).toEqual({
+      id: 1,
+      age: 27,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
+    });
+    expect(plainUser2).toEqual(existUser);
 
-            @Type(type => Date)
-            nullableDate?: null | Date;
-
-            @Type(type => Buffer)
-            nullableBuffer?: null | Buffer;
-        }
-
-        const date = new Date();
-        const user = new User();
-        const uuid = Buffer.from('1234');
-        user.firstName = 321 as any;
-        user.lastName = 123 as any;
-        user.password = "123" as any;
-        user.isActive = "1" as any;
-        user.registrationDate = date.toString() as any;
-        user.lastVisitDate = date as any;
-        user.uuidBuffer = uuid as any;
-        user.nullableString = null as any;
-        user.nullableNumber = null as any;
-        user.nullableBoolean = null as any;
-        user.nullableDate = null as any;
-        user.nullableBuffer = null as any;
-
-        const fromPlainUser = {
-            firstName: 321,
-            lastName: 123,
-            password: "123",
-            isActive: "1",
-            registrationDate: date.toString(),
-            lastVisitDate: date,
-            uuidBuffer: uuid,
-            nullableString: null as null | string,
-            nullableNumber: null as null | string,
-            nullableBoolean: null as null | string,
-            nullableDate: null as null | string,
-            nullableBuffer: null as null | string,
-        };
-
-        const fromExistUser = new User();
-        fromExistUser.id = 1;
-
-        const plainUser: any = classToPlain(user, {strategy: "exposeAll"});
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({
-            firstName: "321",
-            lastName: "123",
-            password: 123,
-            isActive: true,
-            registrationDate: new Date(date.toString()),
-            lastVisitDate: date.toString(),
-            uuidBuffer: uuid,
-            nullableString: null,
-            nullableNumber: null,
-            nullableBoolean: null,
-            nullableDate: null,
-            nullableBuffer: null
-        });
-
-        const existUser = {id: 1, age: 27};
-        const plainUser2 = classToPlainFromExist(user, existUser, {strategy: "exposeAll"});
-        expect(plainUser2).not.toBeInstanceOf(User);
-        expect(plainUser2).toEqual({
-            id: 1,
-            age: 27,
-            firstName: "321",
-            lastName: "123",
-            password: 123,
-            isActive: true,
-            registrationDate: new Date(date.toString()),
-            lastVisitDate: date.toString(),
-            uuidBuffer: uuid,
-            nullableString: null,
-            nullableNumber: null,
-            nullableBoolean: null,
-            nullableDate: null,
-            nullableBuffer: null
-        });
-        expect(plainUser2).toEqual(existUser);
-
-        const transformedUser = plainToClass(User, fromPlainUser, {strategy: "exposeAll"});
-        expect(transformedUser).toBeInstanceOf(User);
-        expect(transformedUser).toEqual({
-            firstName: "321",
-            lastName: "123",
-            password: 123,
-            isActive: true,
-            registrationDate: new Date(date.toString()),
-            lastVisitDate: date.toString(),
-            uuidBuffer: uuid,
-            nullableString: null,
-            nullableNumber: null,
-            nullableBoolean: null,
-            nullableDate: null,
-            nullableBuffer: null
-        });
-
-        const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser, {strategy: "exposeAll"});
-        expect(fromExistTransformedUser).toBeInstanceOf(User);
-        expect(fromExistTransformedUser).toEqual({
-            id: 1,
-            firstName: "321",
-            lastName: "123",
-            password: 123,
-            isActive: true,
-            registrationDate: new Date(date.toString()),
-            lastVisitDate: date.toString(),
-            uuidBuffer: uuid,
-            nullableString: null,
-            nullableNumber: null,
-            nullableBoolean: null,
-            nullableDate: null,
-            nullableBuffer: null
-        });
-
-        const classToClassUser = classToClass(user, {strategy: "exposeAll"});
-        expect(classToClassUser).toBeInstanceOf(User);
-        expect(classToClassUser).not.toEqual(user);
-        expect(classToClassUser).toEqual({
-            firstName: "321",
-            lastName: "123",
-            password: 123,
-            isActive: true,
-            registrationDate: new Date(date.toString()),
-            lastVisitDate: date.toString(),
-            uuidBuffer: uuid,
-            nullableString: null,
-            nullableNumber: null,
-            nullableBoolean: null,
-            nullableDate: null,
-            nullableBuffer: null
-        });
-
-        const classToClassFromExistUser = classToClassFromExist(user, fromExistUser, {strategy: "exposeAll"});
-        expect(classToClassFromExistUser).toBeInstanceOf(User);
-        expect(classToClassFromExistUser).not.toEqual(user);
-        expect(classToClassFromExistUser).toEqual(fromExistUser);
-        expect(classToClassFromExistUser).toEqual({
-            id: 1,
-            firstName: "321",
-            lastName: "123",
-            password: 123,
-            isActive: true,
-            registrationDate: new Date(date.toString()),
-            lastVisitDate: date.toString(),
-            uuidBuffer: uuid,
-            nullableString: null,
-            nullableNumber: null,
-            nullableBoolean: null,
-            nullableDate: null,
-            nullableBuffer: null
-        });
+    const transformedUser = plainToClass(User, fromPlainUser);
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
     });
 
-    it("should transform nested objects too and make sure their decorators are used too", () => {
-        defaultMetadataStorage.clear();
-
-        class Photo {
-            id: number;
-            name: string;
-
-            @Exclude()
-            filename: string;
-
-            uploadDate: Date;
-        }
-
-        class User {
-            firstName: string;
-            lastName: string;
-
-            @Exclude()
-            password: string;
-
-            photo: Photo; // type should be automatically guessed
-        }
-
-        const photo = new Photo();
-        photo.id = 1;
-        photo.name = "Me";
-        photo.filename = "iam.jpg";
-        photo.uploadDate = new Date();
-
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-        user.photo = photo;
-
-        const plainUser: any = classToPlain(user, {strategy: "exposeAll"});
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser.photo).not.toBeInstanceOf(Photo);
-        expect(plainUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                name: "Me",
-                uploadDate: photo.uploadDate
-            }
-        });
-        expect(plainUser.password).toBeUndefined();
-        expect(plainUser.photo.filename).toBeUndefined();
-        expect(plainUser.photo.uploadDate).toEqual(photo.uploadDate);
-        expect(plainUser.photo.uploadDate).not.toBe(photo.uploadDate);
-
-        const existUser = {id: 1, age: 27, photo: {id: 2, description: "photo"}};
-        const plainUser2: any = classToPlainFromExist(user, existUser, {strategy: "exposeAll"});
-        expect(plainUser2).not.toBeInstanceOf(User);
-        expect(plainUser2.photo).not.toBeInstanceOf(Photo);
-        expect(plainUser2).toEqual({
-            id: 1,
-            age: 27,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                name: "Me",
-                uploadDate: photo.uploadDate,
-                description: "photo"
-            }
-        });
-        expect(plainUser2).toEqual(existUser);
-        expect(plainUser2.password).toBeUndefined();
-        expect(plainUser2.photo.filename).toBeUndefined();
-        expect(plainUser2.photo.uploadDate).toEqual(photo.uploadDate);
-        expect(plainUser2.photo.uploadDate).not.toBe(photo.uploadDate);
+    const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
+    expect(fromExistTransformedUser).toBeInstanceOf(User);
+    expect(fromExistTransformedUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
     });
 
-    it("should transform nested objects too and make sure given type is used instead of automatically guessed one", () => {
-        defaultMetadataStorage.clear();
-
-        class Photo {
-            id: number;
-            name: string;
-
-            @Exclude()
-            filename: string;
-        }
-
-        class ExtendedPhoto implements Photo {
-            id: number;
-
-            @Exclude()
-            name: string;
-
-            filename: string;
-        }
-
-        class User {
-            id: number;
-            firstName: string;
-            lastName: string;
-
-            @Exclude()
-            password: string;
-
-            @Type(type => ExtendedPhoto) // force specific type
-            photo: Photo;
-        }
-
-        const photo = new Photo();
-        photo.id = 1;
-        photo.name = "Me";
-        photo.filename = "iam.jpg";
-
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-        user.photo = photo;
-
-        const plainUser: any = classToPlain(user);
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                filename: "iam.jpg"
-            }
-        });
-        expect(plainUser.password).toBeUndefined();
-        expect(plainUser.photo.name).toBeUndefined();
+    const classToClassUser = classToClass(user);
+    expect(classToClassUser).toBeInstanceOf(User);
+    expect(classToClassUser).not.toEqual(user);
+    expect(classToClassUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
     });
 
-    it("should convert given plain object to class instance object", () => {
-        defaultMetadataStorage.clear();
+    const classToClassFromExistUser = classToClassFromExist(user, fromExistUser);
+    expect(classToClassFromExistUser).toBeInstanceOf(User);
+    expect(classToClassFromExistUser).not.toEqual(user);
+    expect(classToClassFromExistUser).toEqual(fromExistUser);
+    expect(classToClassFromExistUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
+    });
+  });
 
-        class Photo {
-            id: number;
-            name: string;
+  it("should exclude all properties from object if its defined via transformation options, but include properties marked with @Expose() decorator", () => {
+    defaultMetadataStorage.clear();
 
-            @Exclude()
-            filename: string;
+    class User {
+      id: number;
 
-            metadata: string;
-            uploadDate: Date;
-        }
+      @Expose()
+      firstName: string;
 
-        class User {
-            id: number;
-            firstName: string;
-            lastName: string;
+      @Expose()
+      lastName: string;
 
-            @Exclude()
-            password: string;
+      password: string;
+    }
 
-            @Type(type => Photo)
-            photo: Photo;
-        }
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
 
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-        user.photo = new Photo();
-        user.photo.id = 1;
-        user.photo.name = "Me";
-        user.photo.filename = "iam.jpg";
-        user.photo.uploadDate = new Date();
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
+    };
 
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman",
-            photo: {
-                id: 1,
-                name: "Me",
-                filename: "iam.jpg",
-                uploadDate: new Date(),
-            }
-        };
+    const fromExistUser = new User();
+    fromExistUser.id = 1;
 
-        const fromExistUser = new User();
-        fromExistUser.id = 1;
-        const fromExistPhoto = new Photo();
-        fromExistPhoto.metadata = "taken by Camera";
-        fromExistUser.photo = fromExistPhoto;
+    const plainUser: any = classToPlain(user, { strategy: "excludeAll" });
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
+    });
+    expect(plainUser.password).toBeUndefined();
 
-        const transformedUser = plainToClass(User, fromPlainUser);
-        expect(transformedUser).toBeInstanceOf(User);
-        expect(transformedUser.photo).toBeInstanceOf(Photo);
-        expect(transformedUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                name: "Me",
-                uploadDate: fromPlainUser.photo.uploadDate
-            }
-        });
+    const existUser = { id: 1, age: 27 };
+    const plainUser2 = classToPlainFromExist(user, existUser, { strategy: "excludeAll" });
+    expect(plainUser2).not.toBeInstanceOf(User);
+    expect(plainUser2).toEqual({
+      id: 1,
+      age: 27,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
+    });
+    expect(plainUser2).toEqual(existUser);
 
-        const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
-        expect(fromExistTransformedUser).toEqual(fromExistUser);
-        expect(fromExistTransformedUser.photo).toEqual(fromExistPhoto);
-        expect(fromExistTransformedUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                name: "Me",
-                metadata: "taken by Camera",
-                uploadDate: fromPlainUser.photo.uploadDate
-            }
-        });
-
-        const classToClassUser = classToClass(user);
-        expect(classToClassUser).toBeInstanceOf(User);
-        expect(classToClassUser.photo).toBeInstanceOf(Photo);
-        expect(classToClassUser).not.toEqual(user);
-        expect(classToClassUser).not.toEqual(user.photo);
-        expect(classToClassUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                name: "Me",
-                uploadDate: user.photo.uploadDate
-            }
-        });
-
-        const classToClassFromExistUser = classToClassFromExist(user, fromExistUser);
-        expect(classToClassFromExistUser).toBeInstanceOf(User);
-        expect(classToClassFromExistUser.photo).toBeInstanceOf(Photo);
-        expect(classToClassFromExistUser).not.toEqual(user);
-        expect(classToClassFromExistUser).not.toEqual(user.photo);
-        expect(classToClassFromExistUser).toEqual(fromExistUser);
-        expect(classToClassFromExistUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                name: "Me",
-                metadata: "taken by Camera",
-                uploadDate: user.photo.uploadDate
-            }
-        });
+    const transformedUser = plainToClass(User, fromPlainUser, { strategy: "excludeAll" });
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
     });
 
-    it("should expose only properties that match given group", () => {
-        defaultMetadataStorage.clear();
-
-        class Photo {
-            id: number;
-
-            @Expose({
-                groups: ["user", "guest"]
-            })
-            filename: string;
-
-            @Expose({
-                groups: ["admin"]
-            })
-            status: number;
-
-            metadata: string;
-        }
-
-        class User {
-            id: number;
-            firstName: string;
-
-            @Expose({
-                groups: ["user", "guest"]
-            })
-            lastName: string;
-
-            @Expose({
-                groups: ["user"]
-            })
-            password: string;
-
-            @Expose({
-                groups: ["admin"]
-            })
-            isActive: boolean;
-
-            @Type(type => Photo)
-            photo: Photo;
-
-            @Expose({
-                groups: ["admin"]
-            })
-            @Type(type => Photo)
-            photos: Photo[];
-        }
-
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-        user.isActive = false;
-        user.photo = new Photo();
-        user.photo.id = 1;
-        user.photo.filename = "myphoto.jpg";
-        user.photo.status = 1;
-        user.photos = [user.photo];
-
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman",
-            isActive: false,
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1
-            },
-            photos: [{
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1,
-            }]
-        };
-
-        const fromExistUser = new User();
-        fromExistUser.id = 1;
-        fromExistUser.photo = new Photo();
-        fromExistUser.photo.metadata = "taken by Camera";
-
-        const plainUser1: any = classToPlain(user);
-        expect(plainUser1).not.toBeInstanceOf(User);
-        expect(plainUser1).toEqual({
-            firstName: "Umed",
-            photo: {
-                id: 1
-            }
-        });
-        expect(plainUser1.lastName).toBeUndefined();
-        expect(plainUser1.password).toBeUndefined();
-        expect(plainUser1.isActive).toBeUndefined();
-
-        const plainUser2: any = classToPlain(user, {groups: ["user"]});
-        expect(plainUser2).not.toBeInstanceOf(User);
-        expect(plainUser2).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman",
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg"
-            }
-        });
-        expect(plainUser2.isActive).toBeUndefined();
-
-        const transformedUser2 = plainToClass(User, fromPlainUser, {groups: ["user"]});
-        expect(transformedUser2).toBeInstanceOf(User);
-        expect(transformedUser2.photo).toBeInstanceOf(Photo);
-        expect(transformedUser2).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman",
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg"
-            }
-        });
-
-        const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser, {groups: ["user"]});
-        expect(fromExistTransformedUser).toEqual(fromExistUser);
-        expect(fromExistTransformedUser.photo).toEqual(fromExistUser.photo);
-        expect(fromExistTransformedUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman",
-            photo: {
-                id: 1,
-                metadata: "taken by Camera",
-                filename: "myphoto.jpg"
-            }
-        });
-
-        const classToClassUser = classToClass(user, {groups: ["user"]});
-        expect(classToClassUser).toBeInstanceOf(User);
-        expect(classToClassUser.photo).toBeInstanceOf(Photo);
-        expect(classToClassUser).not.toEqual(user);
-        expect(classToClassUser).not.toEqual(user.photo);
-        expect(classToClassUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman",
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg"
-            }
-        });
-
-        const classToClassFromExistUser = classToClassFromExist(user, fromExistUser, {groups: ["user"]});
-        expect(classToClassFromExistUser).toBeInstanceOf(User);
-        expect(classToClassFromExistUser.photo).toBeInstanceOf(Photo);
-        expect(classToClassFromExistUser).not.toEqual(user);
-        expect(classToClassFromExistUser).not.toEqual(user.photo);
-        expect(classToClassFromExistUser).toEqual(fromExistUser);
-        expect(classToClassFromExistUser).toEqual({
-            id: 1,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman",
-            photo: {
-                id: 1,
-                metadata: "taken by Camera",
-                filename: "myphoto.jpg"
-            }
-        });
-
-        const plainUser3: any = classToPlain(user, {groups: ["guest"]});
-        expect(plainUser3).not.toBeInstanceOf(User);
-        expect(plainUser3).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg"
-            }
-        });
-        expect(plainUser3.password).toBeUndefined();
-        expect(plainUser3.isActive).toBeUndefined();
-
-        const transformedUser3 = plainToClass(User, fromPlainUser, {groups: ["guest"]});
-        expect(transformedUser3).toBeInstanceOf(User);
-        expect(transformedUser3.photo).toBeInstanceOf(Photo);
-        expect(transformedUser3).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg"
-            }
-        });
-
-        const plainUser4: any = classToPlain(user, {groups: ["admin"]});
-        expect(plainUser4).not.toBeInstanceOf(User);
-        expect(plainUser4).toEqual({
-            firstName: "Umed",
-            isActive: false,
-            photo: {
-                id: 1,
-                status: 1
-            },
-            photos: [{
-                id: 1,
-                status: 1
-            }]
-        });
-        expect(plainUser4.lastName).toBeUndefined();
-        expect(plainUser4.password).toBeUndefined();
-
-        const transformedUser4 = plainToClass(User, fromPlainUser, {groups: ["admin"]});
-        expect(transformedUser4).toBeInstanceOf(User);
-        expect(transformedUser4.photo).toBeInstanceOf(Photo);
-        expect(transformedUser4.photos[0]).toBeInstanceOf(Photo);
-        expect(transformedUser4).toEqual({
-            firstName: "Umed",
-            isActive: false,
-            photo: {
-                id: 1,
-                status: 1
-            },
-            photos: [{
-                id: 1,
-                status: 1
-            }]
-        });
-
-        const plainUser5: any = classToPlain(user, {groups: ["admin", "user"]});
-        expect(plainUser5).not.toBeInstanceOf(User);
-        expect(plainUser5).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman",
-            isActive: false,
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1
-            },
-            photos: [{
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1
-            }]
-        });
-
-        const transformedUser5 = plainToClass(User, fromPlainUser, {groups: ["admin", "user"]});
-        expect(transformedUser5).toBeInstanceOf(User);
-        expect(transformedUser5).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman",
-            isActive: false,
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1
-            },
-            photos: [{
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1
-            }]
-        });
+    const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser, { strategy: "excludeAll" });
+    expect(fromExistTransformedUser).toBeInstanceOf(User);
+    expect(fromExistTransformedUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
     });
 
-    it("should expose only properties that match given version", () => {
-        defaultMetadataStorage.clear();
-
-        class Photo {
-            id: number;
-
-            @Expose({
-                since: 1.5,
-                until: 2
-            })
-            filename: string;
-
-            @Expose({
-                since: 2
-            })
-            status: number;
-        }
-
-        class User {
-            @Expose({
-                since: 1,
-                until: 2
-            })
-            firstName: string;
-
-            @Expose({
-                since: 0.5
-            })
-            lastName: string;
-
-            @Exclude()
-            password: string;
-
-            @Type(type => Photo)
-            photo: Photo;
-
-            @Expose({
-                since: 3
-            })
-            @Type(type => Photo)
-            photos: Photo[];
-        }
-
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-        user.photo = new Photo();
-        user.photo.id = 1;
-        user.photo.filename = "myphoto.jpg";
-        user.photo.status = 1;
-        user.photos = [user.photo];
-
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman",
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1
-            },
-            photos: [{
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1,
-            }]
-        };
-
-        const plainUser1: any = classToPlain(user);
-        expect(plainUser1).not.toBeInstanceOf(User);
-        expect(plainUser1).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1
-            },
-            photos: [{
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1
-            }]
-        });
-
-        const transformedUser1 = plainToClass(User, fromPlainUser);
-        expect(transformedUser1).toBeInstanceOf(User);
-        expect(transformedUser1.photo).toBeInstanceOf(Photo);
-        expect(transformedUser1.photos[0]).toBeInstanceOf(Photo);
-        expect(transformedUser1).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1
-            },
-            photos: [{
-                id: 1,
-                filename: "myphoto.jpg",
-                status: 1
-            }]
-        });
-
-        const plainUser2: any = classToPlain(user, {version: 0.3});
-        expect(plainUser2).not.toBeInstanceOf(User);
-        expect(plainUser2).toEqual({
-            photo: {
-                id: 1
-            }
-        });
-
-        const transformedUser2 = plainToClass(User, fromPlainUser, {version: 0.3});
-        expect(transformedUser2).toBeInstanceOf(User);
-        expect(transformedUser2.photo).toBeInstanceOf(Photo);
-        expect(transformedUser2).toEqual({
-            photo: {
-                id: 1
-            }
-        });
-
-        const plainUser3: any = classToPlain(user, {version: 0.5});
-        expect(plainUser3).not.toBeInstanceOf(User);
-        expect(plainUser3).toEqual({
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1
-            }
-        });
-
-        const transformedUser3 = plainToClass(User, fromPlainUser, {version: 0.5});
-        expect(transformedUser3).toBeInstanceOf(User);
-        expect(transformedUser3.photo).toBeInstanceOf(Photo);
-        expect(transformedUser3).toEqual({
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1
-            }
-        });
-
-        const plainUser4: any = classToPlain(user, {version: 1});
-        expect(plainUser4).not.toBeInstanceOf(User);
-        expect(plainUser4).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1
-            }
-        });
-
-        const transformedUser4 = plainToClass(User, fromPlainUser, {version: 1});
-        expect(transformedUser4).toBeInstanceOf(User);
-        expect(transformedUser4.photo).toBeInstanceOf(Photo);
-        expect(transformedUser4).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1
-            }
-        });
-
-        const plainUser5: any = classToPlain(user, {version: 1.5});
-        expect(plainUser5).not.toBeInstanceOf(User);
-        expect(plainUser5).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg"
-            }
-        });
-
-        const transformedUser5 = plainToClass(User, fromPlainUser, {version: 1.5});
-        expect(transformedUser5).toBeInstanceOf(User);
-        expect(transformedUser5.photo).toBeInstanceOf(Photo);
-        expect(transformedUser5).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                filename: "myphoto.jpg"
-            }
-        });
-
-        const plainUser6: any = classToPlain(user, {version: 2});
-        expect(plainUser6).not.toBeInstanceOf(User);
-        expect(plainUser6).toEqual({
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                status: 1
-            }
-        });
-
-        const transformedUser6 = plainToClass(User, fromPlainUser, {version: 2});
-        expect(transformedUser6).toBeInstanceOf(User);
-        expect(transformedUser6.photo).toBeInstanceOf(Photo);
-        expect(transformedUser6).toEqual({
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                status: 1
-            }
-        });
-
-        const plainUser7: any = classToPlain(user, {version: 3});
-        expect(plainUser7).not.toBeInstanceOf(User);
-        expect(plainUser7).toEqual({
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                status: 1
-            },
-            photos: [{
-                id: 1,
-                status: 1
-            }]
-        });
-
-        const transformedUser7 = plainToClass(User, fromPlainUser, {version: 3});
-        expect(transformedUser7).toBeInstanceOf(User);
-        expect(transformedUser7.photo).toBeInstanceOf(Photo);
-        expect(transformedUser7.photos[0]).toBeInstanceOf(Photo);
-        expect(transformedUser7).toEqual({
-            lastName: "Khudoiberdiev",
-            photo: {
-                id: 1,
-                status: 1
-            },
-            photos: [{
-                id: 1,
-                status: 1
-            }]
-        });
-
+    const classToClassUser = classToClass(user, { strategy: "excludeAll" });
+    expect(classToClassUser).toBeInstanceOf(User);
+    expect(classToClassUser).not.toEqual(user);
+    expect(classToClassUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
     });
 
-    it("should set class as value in plainToClass", () => {
-        defaultMetadataStorage.clear();
-        class ClassValue {}
+    const classToClassFromExistUser = classToClassFromExist(user, fromExistUser, { strategy: "excludeAll" });
+    expect(classToClassFromExistUser).toBeInstanceOf(User);
+    expect(classToClassFromExistUser).not.toEqual(user);
+    expect(classToClassFromExistUser).toEqual(fromExistUser);
+    expect(classToClassFromExistUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev"
+    });
+  });
 
-        class User {
-          classValue: any;
-        }
+  it("should expose all properties from object if its defined via transformation options, but exclude properties marked with @Exclude() decorator", () => {
+    defaultMetadataStorage.clear();
 
-        const data = plainToClass(User, { classValue: ClassValue });
-        data.should.be.instanceOf(User);
-        data.classValue.should.be.eq(ClassValue);
-        const instance = new data.classValue();
-        instance.should.be.instanceOf(ClassValue);
+    class User {
+      id: number;
+      firstName: string;
+
+      @Exclude()
+      lastName: string;
+
+      @Exclude()
+      password: string;
+    }
+
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
+
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
+    };
+
+    const fromExistUser = new User();
+    fromExistUser.id = 1;
+
+    const plainUser: any = classToPlain(user, { strategy: "exposeAll" });
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({
+      firstName: "Umed"
+    });
+    expect(plainUser.lastName).toBeUndefined();
+    expect(plainUser.password).toBeUndefined();
+
+    const existUser = { id: 1, age: 27 };
+    const plainUser2 = classToPlainFromExist(user, existUser, { strategy: "exposeAll" });
+    expect(plainUser2).not.toBeInstanceOf(User);
+    expect(plainUser2).toEqual({
+      id: 1,
+      age: 27,
+      firstName: "Umed"
+    });
+    expect(plainUser2).toEqual(existUser);
+
+    const transformedUser = plainToClass(User, fromPlainUser, { strategy: "exposeAll" });
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toEqual({
+      firstName: "Umed"
     });
 
-    it("should set function as value in plainToClass", () => {
-        defaultMetadataStorage.clear();
-        const testFunction = () => 10;
-
-        class User {
-            testFunction: Function;
-        }
-
-        const data = plainToClass(User, { testFunction });
-        data.should.be.instanceOf(User);
-        data.testFunction.should.be.eq(testFunction);
-        data.testFunction().should.be.eq(10);
+    const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser, { strategy: "exposeAll" });
+    expect(fromExistTransformedUser).toBeInstanceOf(User);
+    expect(fromExistTransformedUser).toEqual({
+      id: 1,
+      firstName: "Umed"
     });
 
-    it("should expose method and accessors that have @Expose()", () => {
-        defaultMetadataStorage.clear();
-
-        class User {
-            firstName: string;
-            lastName: string;
-
-            @Exclude()
-            password: string;
-
-            @Expose()
-            get name(): string {
-                return this.firstName + " " + this.lastName;
-            }
-
-            @Expose()
-            getName(): string {
-                return this.firstName + " " + this.lastName;
-            }
-
-        }
-
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-
-        const fromPlainUser = {
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            password: "imnosuperman"
-        };
-
-        const plainUser: any = classToPlain(user);
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            name: "Umed Khudoiberdiev",
-            getName: "Umed Khudoiberdiev"
-        });
-
-        const transformedUser = plainToClass(User, fromPlainUser);
-        expect(transformedUser).toBeInstanceOf(User);
-        const likeUser = new User();
-        likeUser.firstName = "Umed";
-        likeUser.lastName = "Khudoiberdiev";
-        expect(transformedUser).toEqual(likeUser);
+    const classToClassUser = classToClass(user, { strategy: "exposeAll" });
+    expect(classToClassUser).toBeInstanceOf(User);
+    expect(classToClassUser).not.toEqual(user);
+    expect(classToClassUser).toEqual({
+      firstName: "Umed"
     });
 
-    it("should expose with alternative name if its given", () => {
-        defaultMetadataStorage.clear();
+    const classToClassFromExistUser = classToClassFromExist(user, fromExistUser, { strategy: "exposeAll" });
+    expect(classToClassFromExistUser).toBeInstanceOf(User);
+    expect(classToClassFromExistUser).not.toEqual(user);
+    expect(classToClassFromExistUser).toEqual(fromExistUser);
+    expect(classToClassFromExistUser).toEqual({
+      id: 1,
+      firstName: "Umed"
+    });
+  });
 
-        class User {
-            @Expose({name: "myName"})
-            firstName: string;
+  it("should convert values to specific types if they are set via @Type decorator", () => {
+    defaultMetadataStorage.clear();
 
-            @Expose({name: "secondName"})
-            lastName: string;
+    class User {
+      id: number;
 
-            @Exclude()
-            password: string;
+      @Type(type => String)
+      firstName: string;
 
-            @Expose()
-            get name(): string {
-                return this.firstName + " " + this.lastName;
-            }
+      @Type(type => String)
+      lastName: string;
 
-            @Expose({name: "fullName"})
-            getName(): string {
-                return this.firstName + " " + this.lastName;
-            }
-        }
+      @Type(type => Number)
+      password: number;
 
-        const user = new User();
-        user.firstName = "Umed";
-        user.lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
+      @Type(type => Boolean)
+      isActive: boolean;
 
-        const fromPlainUser = {
-            myName: "Umed",
-            secondName: "Khudoiberdiev",
-            password: "imnosuperman"
-        };
+      @Type(type => Date)
+      registrationDate: Date;
 
-        const plainUser: any = classToPlain(user);
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({
-            myName: "Umed",
-            secondName: "Khudoiberdiev",
-            name: "Umed Khudoiberdiev",
-            fullName: "Umed Khudoiberdiev"
-        });
+      @Type(type => String)
+      lastVisitDate: string;
 
-        const transformedUser = plainToClass(User, fromPlainUser);
-        expect(transformedUser).toBeInstanceOf(User);
-        const likeUser = new User();
-        likeUser.firstName = "Umed";
-        likeUser.lastName = "Khudoiberdiev";
-        expect(transformedUser).toEqual(likeUser);
+      @Type(type => Buffer)
+      uuidBuffer: Buffer;
+
+      @Type(type => String)
+      nullableString?: null | string;
+
+      @Type(type => Number)
+      nullableNumber?: null | number;
+
+      @Type(type => Boolean)
+      nullableBoolean?: null | boolean;
+
+      @Type(type => Date)
+      nullableDate?: null | Date;
+
+      @Type(type => Buffer)
+      nullableBuffer?: null | Buffer;
+    }
+
+    const date = new Date();
+    const user = new User();
+    const uuid = Buffer.from('1234');
+    user.firstName = 321 as any;
+    user.lastName = 123 as any;
+    user.password = "123" as any;
+    user.isActive = "1" as any;
+    user.registrationDate = date.toString() as any;
+    user.lastVisitDate = date as any;
+    user.uuidBuffer = uuid as any;
+    user.nullableString = null as any;
+    user.nullableNumber = null as any;
+    user.nullableBoolean = null as any;
+    user.nullableDate = null as any;
+    user.nullableBuffer = null as any;
+
+    const fromPlainUser = {
+      firstName: 321,
+      lastName: 123,
+      password: "123",
+      isActive: "1",
+      registrationDate: date.toString(),
+      lastVisitDate: date,
+      uuidBuffer: uuid,
+      nullableString: null as null | string,
+      nullableNumber: null as null | string,
+      nullableBoolean: null as null | string,
+      nullableDate: null as null | string,
+      nullableBuffer: null as null | string,
+    };
+
+    const fromExistUser = new User();
+    fromExistUser.id = 1;
+
+    const plainUser: any = classToPlain(user, { strategy: "exposeAll" });
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({
+      firstName: "321",
+      lastName: "123",
+      password: 123,
+      isActive: true,
+      registrationDate: new Date(date.toString()),
+      lastVisitDate: date.toString(),
+      uuidBuffer: uuid,
+      nullableString: null,
+      nullableNumber: null,
+      nullableBoolean: null,
+      nullableDate: null,
+      nullableBuffer: null
     });
 
-    it("should exclude all prefixed properties if prefix is given", () => {
-        defaultMetadataStorage.clear();
+    const existUser = { id: 1, age: 27 };
+    const plainUser2 = classToPlainFromExist(user, existUser, { strategy: "exposeAll" });
+    expect(plainUser2).not.toBeInstanceOf(User);
+    expect(plainUser2).toEqual({
+      id: 1,
+      age: 27,
+      firstName: "321",
+      lastName: "123",
+      password: 123,
+      isActive: true,
+      registrationDate: new Date(date.toString()),
+      lastVisitDate: date.toString(),
+      uuidBuffer: uuid,
+      nullableString: null,
+      nullableNumber: null,
+      nullableBoolean: null,
+      nullableDate: null,
+      nullableBuffer: null
+    });
+    expect(plainUser2).toEqual(existUser);
 
-        class Photo {
-            id: number;
-            $filename: string;
-            status: number;
-        }
-
-        class User {
-            $system: string;
-            _firstName: string;
-            _lastName: string;
-
-            @Exclude()
-            password: string;
-
-            @Type(() => Photo)
-            photo: Photo;
-
-            @Expose()
-            get name(): string {
-                return this._firstName + " " + this._lastName;
-            }
-        }
-
-        const user = new User();
-        user.$system = "@#$%^&*token(*&^%$#@!";
-        user._firstName = "Umed";
-        user._lastName = "Khudoiberdiev";
-        user.password = "imnosuperman";
-        user.photo = new Photo();
-        user.photo.id = 1;
-        user.photo.$filename = "myphoto.jpg";
-        user.photo.status = 1;
-
-        const fromPlainUser = {
-            $system: "@#$%^&*token(*&^%$#@!",
-            _firstName: "Khudoiberdiev",
-            _lastName: "imnosuperman",
-            password: "imnosuperman",
-            photo: {
-                id: 1,
-                $filename: "myphoto.jpg",
-                status: 1,
-            }
-        };
-
-        const plainUser: any = classToPlain(user, {excludePrefixes: ["_", "$"]});
-        expect(plainUser).not.toBeInstanceOf(User);
-        expect(plainUser).toEqual({
-            name: "Umed Khudoiberdiev",
-            photo: {
-                id: 1,
-                status: 1
-            }
-        });
-
-        const transformedUser = plainToClass(User, fromPlainUser, {excludePrefixes: ["_", "$"]});
-        expect(transformedUser).toBeInstanceOf(User);
-        const likeUser = new User();
-        likeUser.photo = new Photo();
-        likeUser.photo.id = 1;
-        likeUser.photo.status = 1;
-        expect(transformedUser).toEqual(likeUser);
+    const transformedUser = plainToClass(User, fromPlainUser, { strategy: "exposeAll" });
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toEqual({
+      firstName: "321",
+      lastName: "123",
+      password: 123,
+      isActive: true,
+      registrationDate: new Date(date.toString()),
+      lastVisitDate: date.toString(),
+      uuidBuffer: uuid,
+      nullableString: null,
+      nullableNumber: null,
+      nullableBoolean: null,
+      nullableDate: null,
+      nullableBuffer: null
     });
 
-    it("should transform array", () => {
-        defaultMetadataStorage.clear();
-
-        class User {
-            id: number;
-            firstName: string;
-            lastName: string;
-
-            @Exclude()
-            password: string;
-
-            @Expose()
-            get name(): string {
-                return this.firstName + " " + this.lastName;
-            }
-        }
-
-        const user1 = new User();
-        user1.firstName = "Umed";
-        user1.lastName = "Khudoiberdiev";
-        user1.password = "imnosuperman";
-
-        const user2 = new User();
-        user2.firstName = "Dima";
-        user2.lastName = "Zotov";
-        user2.password = "imnomesser";
-
-        const users = [user1, user2];
-
-        const plainUsers: any = classToPlain(users);
-        expect(plainUsers).toEqual([{
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            name: "Umed Khudoiberdiev"
-        }, {
-            firstName: "Dima",
-            lastName: "Zotov",
-            name: "Dima Zotov"
-        }]);
-
-        const fromPlainUsers = [{
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            name: "Umed Khudoiberdiev"
-        }, {
-            firstName: "Dima",
-            lastName: "Zotov",
-            name: "Dima Zotov"
-        }];
-
-        const existUsers = [{id: 1, age: 27}, {id: 2, age: 30}];
-        const plainUser2 = classToPlainFromExist(users, existUsers);
-        expect(plainUser2).toEqual([{
-            id: 1,
-            age: 27,
-            firstName: "Umed",
-            lastName: "Khudoiberdiev",
-            name: "Umed Khudoiberdiev"
-        }, {
-            id: 2,
-            age: 30,
-            firstName: "Dima",
-            lastName: "Zotov",
-            name: "Dima Zotov"
-        }]);
-
-        const transformedUser = plainToClass(User, fromPlainUsers);
-
-        expect(transformedUser[0]).toBeInstanceOf(User);
-        expect(transformedUser[1]).toBeInstanceOf(User);
-        const likeUser1 = new User();
-        likeUser1.firstName = "Umed";
-        likeUser1.lastName = "Khudoiberdiev";
-
-        const likeUser2 = new User();
-        likeUser2.firstName = "Dima";
-        likeUser2.lastName = "Zotov";
-        expect(transformedUser).toEqual([likeUser1, likeUser2]);
-
-        const classToClassUsers = classToClass(users);
-        expect(classToClassUsers[0]).toBeInstanceOf(User);
-        expect(classToClassUsers[1]).toBeInstanceOf(User);
-        expect(classToClassUsers[0]).not.toEqual(user1);
-        expect(classToClassUsers[1]).not.toEqual(user1);
-
-        const classUserLike1 = new User();
-        classUserLike1.firstName = "Umed";
-        classUserLike1.lastName = "Khudoiberdiev";
-
-        const classUserLike2 = new User();
-        classUserLike2.firstName = "Dima";
-        classUserLike2.lastName = "Zotov";
-
-        expect(classToClassUsers).toEqual([classUserLike1, classUserLike2]);
-
-        const fromExistUser1 = new User();
-        fromExistUser1.id = 1;
-
-        const fromExistUser2 = new User();
-        fromExistUser2.id = 2;
-
-        const fromExistUsers = [fromExistUser1, fromExistUser2];
-
-        const classToClassFromExistUser = classToClassFromExist(users, fromExistUsers);
-        expect(classToClassFromExistUser[0]).toBeInstanceOf(User);
-        expect(classToClassFromExistUser[1]).toBeInstanceOf(User);
-        expect(classToClassFromExistUser[0]).not.toEqual(user1);
-        expect(classToClassFromExistUser[1]).not.toEqual(user1);
-        expect(classToClassFromExistUser).toEqual(fromExistUsers);
-
-        const fromExistUserLike1 = new User();
-        fromExistUserLike1.id = 1;
-        fromExistUserLike1.firstName = "Umed";
-        fromExistUserLike1.lastName = "Khudoiberdiev";
-
-        const fromExistUserLike2 = new User();
-        fromExistUserLike2.id = 2;
-        fromExistUserLike2.firstName = "Dima";
-        fromExistUserLike2.lastName = "Zotov";
-
-        expect(classToClassFromExistUser).toEqual([fromExistUserLike1, fromExistUserLike2]);
+    const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser, { strategy: "exposeAll" });
+    expect(fromExistTransformedUser).toBeInstanceOf(User);
+    expect(fromExistTransformedUser).toEqual({
+      id: 1,
+      firstName: "321",
+      lastName: "123",
+      password: 123,
+      isActive: true,
+      registrationDate: new Date(date.toString()),
+      lastVisitDate: date.toString(),
+      uuidBuffer: uuid,
+      nullableString: null,
+      nullableNumber: null,
+      nullableBoolean: null,
+      nullableDate: null,
+      nullableBuffer: null
     });
 
-    it("should transform objects with null prototype", () => {
-        class TestClass {
-            prop: string;
-        }
-
-        const obj = Object.create(null);
-        obj.a = "JS FTW";
-
-        const transformedClass = plainToClass(TestClass, obj);
-        expect(transformedClass).toBeInstanceOf(TestClass);
+    const classToClassUser = classToClass(user, { strategy: "exposeAll" });
+    expect(classToClassUser).toBeInstanceOf(User);
+    expect(classToClassUser).not.toEqual(user);
+    expect(classToClassUser).toEqual({
+      firstName: "321",
+      lastName: "123",
+      password: 123,
+      isActive: true,
+      registrationDate: new Date(date.toString()),
+      lastVisitDate: date.toString(),
+      uuidBuffer: uuid,
+      nullableString: null,
+      nullableNumber: null,
+      nullableBoolean: null,
+      nullableDate: null,
+      nullableBuffer: null
     });
 
-    it('should not pollute the prototype with a `__proto__` property',() => {
-        const object = JSON.parse('{"__proto__": { "admin": true }}');
-        const plainObject = {};
-        classToPlainFromExist(object, plainObject);
-        expect((plainObject as any).admin).toEqual(undefined);
+    const classToClassFromExistUser = classToClassFromExist(user, fromExistUser, { strategy: "exposeAll" });
+    expect(classToClassFromExistUser).toBeInstanceOf(User);
+    expect(classToClassFromExistUser).not.toEqual(user);
+    expect(classToClassFromExistUser).toEqual(fromExistUser);
+    expect(classToClassFromExistUser).toEqual({
+      id: 1,
+      firstName: "321",
+      lastName: "123",
+      password: 123,
+      isActive: true,
+      registrationDate: new Date(date.toString()),
+      lastVisitDate: date.toString(),
+      uuidBuffer: uuid,
+      nullableString: null,
+      nullableNumber: null,
+      nullableBoolean: null,
+      nullableDate: null,
+      nullableBuffer: null
+    });
+  });
+
+  it("should transform nested objects too and make sure their decorators are used too", () => {
+    defaultMetadataStorage.clear();
+
+    class Photo {
+      id: number;
+      name: string;
+
+      @Exclude()
+      filename: string;
+
+      uploadDate: Date;
+    }
+
+    class User {
+      firstName: string;
+      lastName: string;
+
+      @Exclude()
+      password: string;
+
+      photo: Photo; // type should be automatically guessed
+    }
+
+    const photo = new Photo();
+    photo.id = 1;
+    photo.name = "Me";
+    photo.filename = "iam.jpg";
+    photo.uploadDate = new Date();
+
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
+    user.photo = photo;
+
+    const plainUser: any = classToPlain(user, { strategy: "exposeAll" });
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser.photo).not.toBeInstanceOf(Photo);
+    expect(plainUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        name: "Me",
+        uploadDate: photo.uploadDate
+      }
+    });
+    expect(plainUser.password).toBeUndefined();
+    expect(plainUser.photo.filename).toBeUndefined();
+    expect(plainUser.photo.uploadDate).toEqual(photo.uploadDate);
+    expect(plainUser.photo.uploadDate).not.toBe(photo.uploadDate);
+
+    const existUser = { id: 1, age: 27, photo: { id: 2, description: "photo" } };
+    const plainUser2: any = classToPlainFromExist(user, existUser, { strategy: "exposeAll" });
+    expect(plainUser2).not.toBeInstanceOf(User);
+    expect(plainUser2.photo).not.toBeInstanceOf(Photo);
+    expect(plainUser2).toEqual({
+      id: 1,
+      age: 27,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        name: "Me",
+        uploadDate: photo.uploadDate,
+        description: "photo"
+      }
+    });
+    expect(plainUser2).toEqual(existUser);
+    expect(plainUser2.password).toBeUndefined();
+    expect(plainUser2.photo.filename).toBeUndefined();
+    expect(plainUser2.photo.uploadDate).toEqual(photo.uploadDate);
+    expect(plainUser2.photo.uploadDate).not.toBe(photo.uploadDate);
+  });
+
+  it("should transform nested objects too and make sure given type is used instead of automatically guessed one", () => {
+    defaultMetadataStorage.clear();
+
+    class Photo {
+      id: number;
+      name: string;
+
+      @Exclude()
+      filename: string;
+    }
+
+    class ExtendedPhoto implements Photo {
+      id: number;
+
+      @Exclude()
+      name: string;
+
+      filename: string;
+    }
+
+    class User {
+      id: number;
+      firstName: string;
+      lastName: string;
+
+      @Exclude()
+      password: string;
+
+      @Type(type => ExtendedPhoto) // force specific type
+      photo: Photo;
+    }
+
+    const photo = new Photo();
+    photo.id = 1;
+    photo.name = "Me";
+    photo.filename = "iam.jpg";
+
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
+    user.photo = photo;
+
+    const plainUser: any = classToPlain(user);
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        filename: "iam.jpg"
+      }
+    });
+    expect(plainUser.password).toBeUndefined();
+    expect(plainUser.photo.name).toBeUndefined();
+  });
+
+  it("should convert given plain object to class instance object", () => {
+    defaultMetadataStorage.clear();
+
+    class Photo {
+      id: number;
+      name: string;
+
+      @Exclude()
+      filename: string;
+
+      metadata: string;
+      uploadDate: Date;
+    }
+
+    class User {
+      id: number;
+      firstName: string;
+      lastName: string;
+
+      @Exclude()
+      password: string;
+
+      @Type(type => Photo)
+      photo: Photo;
+    }
+
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
+    user.photo = new Photo();
+    user.photo.id = 1;
+    user.photo.name = "Me";
+    user.photo.filename = "iam.jpg";
+    user.photo.uploadDate = new Date();
+
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman",
+      photo: {
+        id: 1,
+        name: "Me",
+        filename: "iam.jpg",
+        uploadDate: new Date(),
+      }
+    };
+
+    const fromExistUser = new User();
+    fromExistUser.id = 1;
+    const fromExistPhoto = new Photo();
+    fromExistPhoto.metadata = "taken by Camera";
+    fromExistUser.photo = fromExistPhoto;
+
+    const transformedUser = plainToClass(User, fromPlainUser);
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser.photo).toBeInstanceOf(Photo);
+    expect(transformedUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        name: "Me",
+        uploadDate: fromPlainUser.photo.uploadDate
+      }
     });
 
-    it('should not pollute the prototype with a `constructor.prototype` property',  () => {
-        const object = JSON.parse('{"constructor": { "prototype": { "admin": true }}}');
-        const plainObject = {};
-        classToPlainFromExist(object, plainObject);
-        expect((plainObject as any).admin).toEqual(undefined);
+    const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
+    expect(fromExistTransformedUser).toEqual(fromExistUser);
+    expect(fromExistTransformedUser.photo).toEqual(fromExistPhoto);
+    expect(fromExistTransformedUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        name: "Me",
+        metadata: "taken by Camera",
+        uploadDate: fromPlainUser.photo.uploadDate
+      }
     });
 
-    it("should default union types where the plain type is an array to an array result", () => {
-        class User {
-            name: string;
-        }
-
-        class TestClass {
-            @Type(() => User)
-            usersDefined: User[] | undefined;
-
-            @Type(() => User)
-            usersUndefined: User[] | undefined;
-        }
-
-        const obj = Object.create(null);
-        obj.usersDefined = [{name: "a-name"}];
-        obj.usersUndefined = undefined;
-
-        const transformedClass = plainToClass(TestClass, obj as Record<string, any>);
-
-        expect(transformedClass).toBeInstanceOf(TestClass);
-
-        expect(transformedClass.usersDefined).toBeInstanceOf(Array);
-        expect(transformedClass.usersDefined.length).toEqual(1);
-        expect(transformedClass.usersDefined[0]).toBeInstanceOf(User);
-        expect(transformedClass.usersDefined[0].name).toEqual("a-name");
-
-        expect(transformedClass.usersUndefined).toBeUndefined();
+    const classToClassUser = classToClass(user);
+    expect(classToClassUser).toBeInstanceOf(User);
+    expect(classToClassUser.photo).toBeInstanceOf(Photo);
+    expect(classToClassUser).not.toEqual(user);
+    expect(classToClassUser).not.toEqual(user.photo);
+    expect(classToClassUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        name: "Me",
+        uploadDate: user.photo.uploadDate
+      }
     });
+
+    const classToClassFromExistUser = classToClassFromExist(user, fromExistUser);
+    expect(classToClassFromExistUser).toBeInstanceOf(User);
+    expect(classToClassFromExistUser.photo).toBeInstanceOf(Photo);
+    expect(classToClassFromExistUser).not.toEqual(user);
+    expect(classToClassFromExistUser).not.toEqual(user.photo);
+    expect(classToClassFromExistUser).toEqual(fromExistUser);
+    expect(classToClassFromExistUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        name: "Me",
+        metadata: "taken by Camera",
+        uploadDate: user.photo.uploadDate
+      }
+    });
+  });
+
+  it("should expose only properties that match given group", () => {
+    defaultMetadataStorage.clear();
+
+    class Photo {
+      id: number;
+
+      @Expose({
+        groups: ["user", "guest"]
+      })
+      filename: string;
+
+      @Expose({
+        groups: ["admin"]
+      })
+      status: number;
+
+      metadata: string;
+    }
+
+    class User {
+      id: number;
+      firstName: string;
+
+      @Expose({
+        groups: ["user", "guest"]
+      })
+      lastName: string;
+
+      @Expose({
+        groups: ["user"]
+      })
+      password: string;
+
+      @Expose({
+        groups: ["admin"]
+      })
+      isActive: boolean;
+
+      @Type(type => Photo)
+      photo: Photo;
+
+      @Expose({
+        groups: ["admin"]
+      })
+      @Type(type => Photo)
+      photos: Photo[];
+    }
+
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
+    user.isActive = false;
+    user.photo = new Photo();
+    user.photo.id = 1;
+    user.photo.filename = "myphoto.jpg";
+    user.photo.status = 1;
+    user.photos = [user.photo];
+
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman",
+      isActive: false,
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1
+      },
+      photos: [{
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1,
+      }]
+    };
+
+    const fromExistUser = new User();
+    fromExistUser.id = 1;
+    fromExistUser.photo = new Photo();
+    fromExistUser.photo.metadata = "taken by Camera";
+
+    const plainUser1: any = classToPlain(user);
+    expect(plainUser1).not.toBeInstanceOf(User);
+    expect(plainUser1).toEqual({
+      firstName: "Umed",
+      photo: {
+        id: 1
+      }
+    });
+    expect(plainUser1.lastName).toBeUndefined();
+    expect(plainUser1.password).toBeUndefined();
+    expect(plainUser1.isActive).toBeUndefined();
+
+    const plainUser2: any = classToPlain(user, { groups: ["user"] });
+    expect(plainUser2).not.toBeInstanceOf(User);
+    expect(plainUser2).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman",
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg"
+      }
+    });
+    expect(plainUser2.isActive).toBeUndefined();
+
+    const transformedUser2 = plainToClass(User, fromPlainUser, { groups: ["user"] });
+    expect(transformedUser2).toBeInstanceOf(User);
+    expect(transformedUser2.photo).toBeInstanceOf(Photo);
+    expect(transformedUser2).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman",
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg"
+      }
+    });
+
+    const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser, { groups: ["user"] });
+    expect(fromExistTransformedUser).toEqual(fromExistUser);
+    expect(fromExistTransformedUser.photo).toEqual(fromExistUser.photo);
+    expect(fromExistTransformedUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman",
+      photo: {
+        id: 1,
+        metadata: "taken by Camera",
+        filename: "myphoto.jpg"
+      }
+    });
+
+    const classToClassUser = classToClass(user, { groups: ["user"] });
+    expect(classToClassUser).toBeInstanceOf(User);
+    expect(classToClassUser.photo).toBeInstanceOf(Photo);
+    expect(classToClassUser).not.toEqual(user);
+    expect(classToClassUser).not.toEqual(user.photo);
+    expect(classToClassUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman",
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg"
+      }
+    });
+
+    const classToClassFromExistUser = classToClassFromExist(user, fromExistUser, { groups: ["user"] });
+    expect(classToClassFromExistUser).toBeInstanceOf(User);
+    expect(classToClassFromExistUser.photo).toBeInstanceOf(Photo);
+    expect(classToClassFromExistUser).not.toEqual(user);
+    expect(classToClassFromExistUser).not.toEqual(user.photo);
+    expect(classToClassFromExistUser).toEqual(fromExistUser);
+    expect(classToClassFromExistUser).toEqual({
+      id: 1,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman",
+      photo: {
+        id: 1,
+        metadata: "taken by Camera",
+        filename: "myphoto.jpg"
+      }
+    });
+
+    const plainUser3: any = classToPlain(user, { groups: ["guest"] });
+    expect(plainUser3).not.toBeInstanceOf(User);
+    expect(plainUser3).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg"
+      }
+    });
+    expect(plainUser3.password).toBeUndefined();
+    expect(plainUser3.isActive).toBeUndefined();
+
+    const transformedUser3 = plainToClass(User, fromPlainUser, { groups: ["guest"] });
+    expect(transformedUser3).toBeInstanceOf(User);
+    expect(transformedUser3.photo).toBeInstanceOf(Photo);
+    expect(transformedUser3).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg"
+      }
+    });
+
+    const plainUser4: any = classToPlain(user, { groups: ["admin"] });
+    expect(plainUser4).not.toBeInstanceOf(User);
+    expect(plainUser4).toEqual({
+      firstName: "Umed",
+      isActive: false,
+      photo: {
+        id: 1,
+        status: 1
+      },
+      photos: [{
+        id: 1,
+        status: 1
+      }]
+    });
+    expect(plainUser4.lastName).toBeUndefined();
+    expect(plainUser4.password).toBeUndefined();
+
+    const transformedUser4 = plainToClass(User, fromPlainUser, { groups: ["admin"] });
+    expect(transformedUser4).toBeInstanceOf(User);
+    expect(transformedUser4.photo).toBeInstanceOf(Photo);
+    expect(transformedUser4.photos[0]).toBeInstanceOf(Photo);
+    expect(transformedUser4).toEqual({
+      firstName: "Umed",
+      isActive: false,
+      photo: {
+        id: 1,
+        status: 1
+      },
+      photos: [{
+        id: 1,
+        status: 1
+      }]
+    });
+
+    const plainUser5: any = classToPlain(user, { groups: ["admin", "user"] });
+    expect(plainUser5).not.toBeInstanceOf(User);
+    expect(plainUser5).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman",
+      isActive: false,
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1
+      },
+      photos: [{
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1
+      }]
+    });
+
+    const transformedUser5 = plainToClass(User, fromPlainUser, { groups: ["admin", "user"] });
+    expect(transformedUser5).toBeInstanceOf(User);
+    expect(transformedUser5).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman",
+      isActive: false,
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1
+      },
+      photos: [{
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1
+      }]
+    });
+  });
+
+  it("should expose only properties that match given version", () => {
+    defaultMetadataStorage.clear();
+
+    class Photo {
+      id: number;
+
+      @Expose({
+        since: 1.5,
+        until: 2
+      })
+      filename: string;
+
+      @Expose({
+        since: 2
+      })
+      status: number;
+    }
+
+    class User {
+      @Expose({
+        since: 1,
+        until: 2
+      })
+      firstName: string;
+
+      @Expose({
+        since: 0.5
+      })
+      lastName: string;
+
+      @Exclude()
+      password: string;
+
+      @Type(type => Photo)
+      photo: Photo;
+
+      @Expose({
+        since: 3
+      })
+      @Type(type => Photo)
+      photos: Photo[];
+    }
+
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
+    user.photo = new Photo();
+    user.photo.id = 1;
+    user.photo.filename = "myphoto.jpg";
+    user.photo.status = 1;
+    user.photos = [user.photo];
+
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman",
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1
+      },
+      photos: [{
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1,
+      }]
+    };
+
+    const plainUser1: any = classToPlain(user);
+    expect(plainUser1).not.toBeInstanceOf(User);
+    expect(plainUser1).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1
+      },
+      photos: [{
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1
+      }]
+    });
+
+    const transformedUser1 = plainToClass(User, fromPlainUser);
+    expect(transformedUser1).toBeInstanceOf(User);
+    expect(transformedUser1.photo).toBeInstanceOf(Photo);
+    expect(transformedUser1.photos[0]).toBeInstanceOf(Photo);
+    expect(transformedUser1).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1
+      },
+      photos: [{
+        id: 1,
+        filename: "myphoto.jpg",
+        status: 1
+      }]
+    });
+
+    const plainUser2: any = classToPlain(user, { version: 0.3 });
+    expect(plainUser2).not.toBeInstanceOf(User);
+    expect(plainUser2).toEqual({
+      photo: {
+        id: 1
+      }
+    });
+
+    const transformedUser2 = plainToClass(User, fromPlainUser, { version: 0.3 });
+    expect(transformedUser2).toBeInstanceOf(User);
+    expect(transformedUser2.photo).toBeInstanceOf(Photo);
+    expect(transformedUser2).toEqual({
+      photo: {
+        id: 1
+      }
+    });
+
+    const plainUser3: any = classToPlain(user, { version: 0.5 });
+    expect(plainUser3).not.toBeInstanceOf(User);
+    expect(plainUser3).toEqual({
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1
+      }
+    });
+
+    const transformedUser3 = plainToClass(User, fromPlainUser, { version: 0.5 });
+    expect(transformedUser3).toBeInstanceOf(User);
+    expect(transformedUser3.photo).toBeInstanceOf(Photo);
+    expect(transformedUser3).toEqual({
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1
+      }
+    });
+
+    const plainUser4: any = classToPlain(user, { version: 1 });
+    expect(plainUser4).not.toBeInstanceOf(User);
+    expect(plainUser4).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1
+      }
+    });
+
+    const transformedUser4 = plainToClass(User, fromPlainUser, { version: 1 });
+    expect(transformedUser4).toBeInstanceOf(User);
+    expect(transformedUser4.photo).toBeInstanceOf(Photo);
+    expect(transformedUser4).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1
+      }
+    });
+
+    const plainUser5: any = classToPlain(user, { version: 1.5 });
+    expect(plainUser5).not.toBeInstanceOf(User);
+    expect(plainUser5).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg"
+      }
+    });
+
+    const transformedUser5 = plainToClass(User, fromPlainUser, { version: 1.5 });
+    expect(transformedUser5).toBeInstanceOf(User);
+    expect(transformedUser5.photo).toBeInstanceOf(Photo);
+    expect(transformedUser5).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        filename: "myphoto.jpg"
+      }
+    });
+
+    const plainUser6: any = classToPlain(user, { version: 2 });
+    expect(plainUser6).not.toBeInstanceOf(User);
+    expect(plainUser6).toEqual({
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        status: 1
+      }
+    });
+
+    const transformedUser6 = plainToClass(User, fromPlainUser, { version: 2 });
+    expect(transformedUser6).toBeInstanceOf(User);
+    expect(transformedUser6.photo).toBeInstanceOf(Photo);
+    expect(transformedUser6).toEqual({
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        status: 1
+      }
+    });
+
+    const plainUser7: any = classToPlain(user, { version: 3 });
+    expect(plainUser7).not.toBeInstanceOf(User);
+    expect(plainUser7).toEqual({
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        status: 1
+      },
+      photos: [{
+        id: 1,
+        status: 1
+      }]
+    });
+
+    const transformedUser7 = plainToClass(User, fromPlainUser, { version: 3 });
+    expect(transformedUser7).toBeInstanceOf(User);
+    expect(transformedUser7.photo).toBeInstanceOf(Photo);
+    expect(transformedUser7.photos[0]).toBeInstanceOf(Photo);
+    expect(transformedUser7).toEqual({
+      lastName: "Khudoiberdiev",
+      photo: {
+        id: 1,
+        status: 1
+      },
+      photos: [{
+        id: 1,
+        status: 1
+      }]
+    });
+
+  });
+
+  it("should set class as value in plainToClass", () => {
+    defaultMetadataStorage.clear();
+    class ClassValue { }
+
+    class User {
+      classValue: any;
+    }
+
+    const data = plainToClass(User, { classValue: ClassValue });
+    expect(data).toBeInstanceOf(User);
+    data.classValue.should.be.eq(ClassValue);
+    const instance = new data.classValue();
+    instance.should.be.instanceOf(ClassValue);
+  });
+
+  it("should set function as value in plainToClass", () => {
+    defaultMetadataStorage.clear();
+    const testFunction = () => 10;
+
+    class User {
+      testFunction: Function;
+    }
+
+    const data = plainToClass(User, { testFunction });
+    expect(data).toBeInstanceOf(User);
+    expect(data.testFunction).toEqual(testFunction);
+    data.testFunction().should.be.eq(10);
+  });
+
+  it("should expose method and accessors that have @Expose()", () => {
+    defaultMetadataStorage.clear();
+
+    class User {
+      firstName: string;
+      lastName: string;
+
+      @Exclude()
+      password: string;
+
+      @Expose()
+      get name(): string {
+        return this.firstName + " " + this.lastName;
+      }
+
+      @Expose()
+      getName(): string {
+        return this.firstName + " " + this.lastName;
+      }
+
+    }
+
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
+
+    const fromPlainUser = {
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      password: "imnosuperman"
+    };
+
+    const plainUser: any = classToPlain(user);
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      name: "Umed Khudoiberdiev",
+      getName: "Umed Khudoiberdiev"
+    });
+
+    const transformedUser = plainToClass(User, fromPlainUser);
+    expect(transformedUser).toBeInstanceOf(User);
+    const likeUser = new User();
+    likeUser.firstName = "Umed";
+    likeUser.lastName = "Khudoiberdiev";
+    expect(transformedUser).toEqual(likeUser);
+  });
+
+  it("should expose with alternative name if its given", () => {
+    defaultMetadataStorage.clear();
+
+    class User {
+      @Expose({ name: "myName" })
+      firstName: string;
+
+      @Expose({ name: "secondName" })
+      lastName: string;
+
+      @Exclude()
+      password: string;
+
+      @Expose()
+      get name(): string {
+        return this.firstName + " " + this.lastName;
+      }
+
+      @Expose({ name: "fullName" })
+      getName(): string {
+        return this.firstName + " " + this.lastName;
+      }
+    }
+
+    const user = new User();
+    user.firstName = "Umed";
+    user.lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
+
+    const fromPlainUser = {
+      myName: "Umed",
+      secondName: "Khudoiberdiev",
+      password: "imnosuperman"
+    };
+
+    const plainUser: any = classToPlain(user);
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({
+      myName: "Umed",
+      secondName: "Khudoiberdiev",
+      name: "Umed Khudoiberdiev",
+      fullName: "Umed Khudoiberdiev"
+    });
+
+    const transformedUser = plainToClass(User, fromPlainUser);
+    expect(transformedUser).toBeInstanceOf(User);
+    const likeUser = new User();
+    likeUser.firstName = "Umed";
+    likeUser.lastName = "Khudoiberdiev";
+    expect(transformedUser).toEqual(likeUser);
+  });
+
+  it("should exclude all prefixed properties if prefix is given", () => {
+    defaultMetadataStorage.clear();
+
+    class Photo {
+      id: number;
+      $filename: string;
+      status: number;
+    }
+
+    class User {
+      $system: string;
+      _firstName: string;
+      _lastName: string;
+
+      @Exclude()
+      password: string;
+
+      @Type(() => Photo)
+      photo: Photo;
+
+      @Expose()
+      get name(): string {
+        return this._firstName + " " + this._lastName;
+      }
+    }
+
+    const user = new User();
+    user.$system = "@#$%^&*token(*&^%$#@!";
+    user._firstName = "Umed";
+    user._lastName = "Khudoiberdiev";
+    user.password = "imnosuperman";
+    user.photo = new Photo();
+    user.photo.id = 1;
+    user.photo.$filename = "myphoto.jpg";
+    user.photo.status = 1;
+
+    const fromPlainUser = {
+      $system: "@#$%^&*token(*&^%$#@!",
+      _firstName: "Khudoiberdiev",
+      _lastName: "imnosuperman",
+      password: "imnosuperman",
+      photo: {
+        id: 1,
+        $filename: "myphoto.jpg",
+        status: 1,
+      }
+    };
+
+    const plainUser: any = classToPlain(user, { excludePrefixes: ["_", "$"] });
+    expect(plainUser).not.toBeInstanceOf(User);
+    expect(plainUser).toEqual({
+      name: "Umed Khudoiberdiev",
+      photo: {
+        id: 1,
+        status: 1
+      }
+    });
+
+    const transformedUser = plainToClass(User, fromPlainUser, { excludePrefixes: ["_", "$"] });
+    expect(transformedUser).toBeInstanceOf(User);
+    const likeUser = new User();
+    likeUser.photo = new Photo();
+    likeUser.photo.id = 1;
+    likeUser.photo.status = 1;
+    expect(transformedUser).toEqual(likeUser);
+  });
+
+  it("should transform array", () => {
+    defaultMetadataStorage.clear();
+
+    class User {
+      id: number;
+      firstName: string;
+      lastName: string;
+
+      @Exclude()
+      password: string;
+
+      @Expose()
+      get name(): string {
+        return this.firstName + " " + this.lastName;
+      }
+    }
+
+    const user1 = new User();
+    user1.firstName = "Umed";
+    user1.lastName = "Khudoiberdiev";
+    user1.password = "imnosuperman";
+
+    const user2 = new User();
+    user2.firstName = "Dima";
+    user2.lastName = "Zotov";
+    user2.password = "imnomesser";
+
+    const users = [user1, user2];
+
+    const plainUsers: any = classToPlain(users);
+    expect(plainUsers).toEqual([{
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      name: "Umed Khudoiberdiev"
+    }, {
+      firstName: "Dima",
+      lastName: "Zotov",
+      name: "Dima Zotov"
+    }]);
+
+    const fromPlainUsers = [{
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      name: "Umed Khudoiberdiev"
+    }, {
+      firstName: "Dima",
+      lastName: "Zotov",
+      name: "Dima Zotov"
+    }];
+
+    const existUsers = [{ id: 1, age: 27 }, { id: 2, age: 30 }];
+    const plainUser2 = classToPlainFromExist(users, existUsers);
+    expect(plainUser2).toEqual([{
+      id: 1,
+      age: 27,
+      firstName: "Umed",
+      lastName: "Khudoiberdiev",
+      name: "Umed Khudoiberdiev"
+    }, {
+      id: 2,
+      age: 30,
+      firstName: "Dima",
+      lastName: "Zotov",
+      name: "Dima Zotov"
+    }]);
+
+    const transformedUser = plainToClass(User, fromPlainUsers);
+
+    expect(transformedUser[0]).toBeInstanceOf(User);
+    expect(transformedUser[1]).toBeInstanceOf(User);
+    const likeUser1 = new User();
+    likeUser1.firstName = "Umed";
+    likeUser1.lastName = "Khudoiberdiev";
+
+    const likeUser2 = new User();
+    likeUser2.firstName = "Dima";
+    likeUser2.lastName = "Zotov";
+    expect(transformedUser).toEqual([likeUser1, likeUser2]);
+
+    const classToClassUsers = classToClass(users);
+    expect(classToClassUsers[0]).toBeInstanceOf(User);
+    expect(classToClassUsers[1]).toBeInstanceOf(User);
+    expect(classToClassUsers[0]).not.toEqual(user1);
+    expect(classToClassUsers[1]).not.toEqual(user1);
+
+    const classUserLike1 = new User();
+    classUserLike1.firstName = "Umed";
+    classUserLike1.lastName = "Khudoiberdiev";
+
+    const classUserLike2 = new User();
+    classUserLike2.firstName = "Dima";
+    classUserLike2.lastName = "Zotov";
+
+    expect(classToClassUsers).toEqual([classUserLike1, classUserLike2]);
+
+    const fromExistUser1 = new User();
+    fromExistUser1.id = 1;
+
+    const fromExistUser2 = new User();
+    fromExistUser2.id = 2;
+
+    const fromExistUsers = [fromExistUser1, fromExistUser2];
+
+    const classToClassFromExistUser = classToClassFromExist(users, fromExistUsers);
+    expect(classToClassFromExistUser[0]).toBeInstanceOf(User);
+    expect(classToClassFromExistUser[1]).toBeInstanceOf(User);
+    expect(classToClassFromExistUser[0]).not.toEqual(user1);
+    expect(classToClassFromExistUser[1]).not.toEqual(user1);
+    expect(classToClassFromExistUser).toEqual(fromExistUsers);
+
+    const fromExistUserLike1 = new User();
+    fromExistUserLike1.id = 1;
+    fromExistUserLike1.firstName = "Umed";
+    fromExistUserLike1.lastName = "Khudoiberdiev";
+
+    const fromExistUserLike2 = new User();
+    fromExistUserLike2.id = 2;
+    fromExistUserLike2.firstName = "Dima";
+    fromExistUserLike2.lastName = "Zotov";
+
+    expect(classToClassFromExistUser).toEqual([fromExistUserLike1, fromExistUserLike2]);
+  });
+
+  it("should transform objects with null prototype", () => {
+    class TestClass {
+      prop: string;
+    }
+
+    const obj = Object.create(null);
+    obj.a = "JS FTW";
+
+    const transformedClass = plainToClass(TestClass, obj);
+    expect(transformedClass).toBeInstanceOf(TestClass);
+  });
+
+  it('should not pollute the prototype with a `__proto__` property', () => {
+    const object = JSON.parse('{"__proto__": { "admin": true }}');
+    const plainObject = {};
+    classToPlainFromExist(object, plainObject);
+    expect((plainObject as any).admin).toEqual(undefined);
+  });
+
+  it('should not pollute the prototype with a `constructor.prototype` property', () => {
+    const object = JSON.parse('{"constructor": { "prototype": { "admin": true }}}');
+    const plainObject = {};
+    classToPlainFromExist(object, plainObject);
+    expect((plainObject as any).admin).toEqual(undefined);
+  });
+
+  it("should default union types where the plain type is an array to an array result", () => {
+    class User {
+      name: string;
+    }
+
+    class TestClass {
+      @Type(() => User)
+      usersDefined: User[] | undefined;
+
+      @Type(() => User)
+      usersUndefined: User[] | undefined;
+    }
+
+    const obj = Object.create(null);
+    obj.usersDefined = [{ name: "a-name" }];
+    obj.usersUndefined = undefined;
+
+    const transformedClass = plainToClass(TestClass, obj as Record<string, any>);
+
+    expect(transformedClass).toBeInstanceOf(TestClass);
+
+    expect(transformedClass.usersDefined).toBeInstanceOf(Array);
+    expect(transformedClass.usersDefined.length).toEqual(1);
+    expect(transformedClass.usersDefined[0]).toBeInstanceOf(User);
+    expect(transformedClass.usersDefined[0].name).toEqual("a-name");
+
+    expect(transformedClass.usersUndefined).toBeUndefined();
+  });
 });

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -1455,9 +1455,9 @@ describe("basic functionality", () => {
 
     const data = plainToClass(User, { classValue: ClassValue });
     expect(data).toBeInstanceOf(User);
-    data.classValue.should.be.eq(ClassValue);
+    expect(data.classValue).toEqual(ClassValue);
     const instance = new data.classValue();
-    instance.should.be.instanceOf(ClassValue);
+    expect(instance).toBeInstanceOf(ClassValue);
   });
 
   it("should set function as value in plainToClass", () => {
@@ -1471,7 +1471,7 @@ describe("basic functionality", () => {
     const data = plainToClass(User, { testFunction });
     expect(data).toBeInstanceOf(User);
     expect(data.testFunction).toEqual(testFunction);
-    data.testFunction().should.be.eq(10);
+    expect(data.testFunction()).toEqual(10);
   });
 
   it("should expose method and accessors that have @Expose()", () => {


### PR DESCRIPTION
This PR updates the [PR#275](https://github.com/typestack/class-transformer/pull/275) with the latest from the `develop` branch and also fixes the test specs to use Jest `expect`instead of plain `should` checks.

references #242, #276