### PR TITLE
fix: prevent cyclic import warnings via moving TransformationType into a separate file

### DIFF
--- a/src/ClassTransformer.ts
+++ b/src/ClassTransformer.ts
@@ -1,6 +1,6 @@
 import { ClassTransformOptions } from './ClassTransformOptions';
-import { TransformOperationExecutor, TransformationType } from './TransformOperationExecutor';
-
+import { TransformOperationExecutor } from './TransformOperationExecutor';
+import { TransformationType } from './TransformationType';
 export type ClassType<T> = {
   new (...args: any[]): T;
 };

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -2,12 +2,7 @@ import { ClassTransformOptions } from './ClassTransformOptions';
 import { defaultMetadataStorage } from './storage';
 import { TypeHelpOptions, TypeOptions } from './metadata/ExposeExcludeOptions';
 import { TypeMetadata } from './metadata/TypeMetadata';
-
-export enum TransformationType {
-  PLAIN_TO_CLASS,
-  CLASS_TO_PLAIN,
-  CLASS_TO_CLASS,
-}
+import { TransformationType } from './TransformationType';
 
 export function testForBuffer(): boolean {
   try {

--- a/src/TransformationType.ts
+++ b/src/TransformationType.ts
@@ -1,0 +1,5 @@
+export enum TransformationType {
+    PLAIN_TO_CLASS,
+    CLASS_TO_PLAIN,
+    CLASS_TO_CLASS
+}

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -12,7 +12,7 @@ import {
 import { ExcludeMetadata } from './metadata/ExcludeMetadata';
 import { TransformMetadata } from './metadata/TransformMetadata';
 import { ClassTransformOptions } from './ClassTransformOptions';
-import { TransformationType } from './TransformOperationExecutor';
+import { TransformationType } from './TransformationType';
 
 /**
  * Defines a custom logic for value transformation.

--- a/src/metadata/MetadataStorage.ts
+++ b/src/metadata/MetadataStorage.ts
@@ -1,7 +1,7 @@
 import { TypeMetadata } from './TypeMetadata';
 import { ExposeMetadata } from './ExposeMetadata';
 import { ExcludeMetadata } from './ExcludeMetadata';
-import { TransformationType } from '../TransformOperationExecutor';
+import { TransformationType } from '../TransformationType';
 import { TransformMetadata } from './TransformMetadata';
 
 /**

--- a/src/metadata/TransformMetadata.ts
+++ b/src/metadata/TransformMetadata.ts
@@ -1,5 +1,5 @@
 import { TransformOptions } from './ExposeExcludeOptions';
-import { TransformationType } from '../TransformOperationExecutor';
+import { TransformationType } from '../TransformationType';
 
 export class TransformMetadata {
   constructor(

--- a/test/functional/custom-transform.spec.ts
+++ b/test/functional/custom-transform.spec.ts
@@ -3,7 +3,7 @@ import 'reflect-metadata';
 import { classToClass, classToPlain, plainToClass } from '../../src/index';
 import { defaultMetadataStorage } from '../../src/storage';
 import { Expose, Transform, Type } from '../../src/decorators';
-import { TransformationType } from '../../src/TransformOperationExecutor';
+import { TransformationType } from '../../src/TransformationType';
 import dayjs from 'dayjs';
 
 describe('custom transformation decorator', () => {


### PR DESCRIPTION
This PR extracts TransformationType into a separate file to prevent cyclic import warnings.

fixes #358