### PR TITLE
feat: set default value if nothing provided

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -294,14 +294,19 @@ export class TransformOperationExecutor {
             // Apply the default transformation
             finalValue = this.transform(subSource, finalValue, type, arrayType, isSubValueMap, level + 1);
           } else {
-            finalValue = this.transform(subSource, subValue, type, arrayType, isSubValueMap, level + 1);
-            finalValue = this.applyCustomTransformations(
-              finalValue,
-              targetType as Function,
-              transformKey,
-              value,
-              this.transformationType
-            );
+            if (subValue === undefined) {
+              // Set default value if nothing provided
+              finalValue = newValue[newValueKey];
+            } else {
+              finalValue = this.transform(subSource, subValue, type, arrayType, isSubValueMap, level + 1);
+              finalValue = this.applyCustomTransformations(
+                finalValue,
+                targetType as Function,
+                transformKey,
+                value,
+                this.transformationType
+              );
+            }
           }
 
           if (newValue instanceof Map) {

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -294,7 +294,7 @@ export class TransformOperationExecutor {
             // Apply the default transformation
             finalValue = this.transform(subSource, finalValue, type, arrayType, isSubValueMap, level + 1);
           } else {
-            if (subValue === undefined) {
+            if (subValue === undefined && this.options.exposeDefaultValues) {
               // Set default value if nothing provided
               finalValue = newValue[newValueKey];
             } else {

--- a/src/interfaces/class-transformer-options.interface.ts
+++ b/src/interfaces/class-transformer-options.interface.ts
@@ -57,4 +57,10 @@ export interface ClassTransformOptions {
    * DEFAULT: `false`
    */
   enableImplicitConversion?: boolean;
+
+  /**
+   * If set to true then class transformer will take default values for unprovided fields.
+   * This is useful when you convert a plain object to a class and have an optional field with a default value.
+   */
+  exposeDefaultValues?: boolean;
 }

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -8,7 +8,7 @@ import {
   plainToClassFromExist,
 } from '../../src/index';
 import { defaultMetadataStorage } from '../../src/storage';
-import { Exclude, Expose, Type } from '../../src/decorators';
+import { Exclude, Expose, Type, Transform } from '../../src/decorators';
 
 describe('basic functionality', () => {
   it('should convert instance of the given object to plain javascript object and should expose all properties since its a default behaviour', () => {
@@ -1818,5 +1818,48 @@ describe('basic functionality', () => {
     expect(transformedClass.usersDefined[0].name).toEqual('a-name');
 
     expect(transformedClass.usersUndefined).toBeUndefined();
+  });
+
+  it('should set default value if nothing provided', () => {
+    defaultMetadataStorage.clear();
+
+    class User {
+      @Expose({ name: 'AGE' })
+      @Transform(value => parseInt(value, 10))
+      age: number;
+
+      @Expose({ name: 'AGE_WITH_DEFAULT' })
+      @Transform(value => parseInt(value, 10))
+      ageWithDefault: number = 18;
+
+      @Expose({ name: 'FIRST_NAME' })
+      firstName: string;
+
+      @Expose({ name: 'FIRST_NAME_WITH_DEFAULT' })
+      firstNameWithDefault: string = 'default first name';
+
+      @Transform(value => !!value)
+      admin: boolean;
+
+      @Transform(value => !!value)
+      adminWithDefault: boolean = false;
+
+      lastName: string;
+
+      lastNameWithDefault: string = 'default last name';
+    }
+
+    const fromPlainUser = {};
+    const transformedUser = plainToClass(User, fromPlainUser);
+
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toEqual({
+      age: undefined,
+      ageWithDefault: 18,
+      firstName: undefined,
+      firstNameWithDefault: 'default first name',
+      adminWithDefault: false,
+      lastNameWithDefault: 'default last name',
+    });
   });
 });

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -1819,47 +1819,4 @@ describe('basic functionality', () => {
 
     expect(transformedClass.usersUndefined).toBeUndefined();
   });
-
-  it('should set default value if nothing provided', () => {
-    defaultMetadataStorage.clear();
-
-    class User {
-      @Expose({ name: 'AGE' })
-      @Transform(value => parseInt(value, 10))
-      age: number;
-
-      @Expose({ name: 'AGE_WITH_DEFAULT' })
-      @Transform(value => parseInt(value, 10))
-      ageWithDefault: number = 18;
-
-      @Expose({ name: 'FIRST_NAME' })
-      firstName: string;
-
-      @Expose({ name: 'FIRST_NAME_WITH_DEFAULT' })
-      firstNameWithDefault: string = 'default first name';
-
-      @Transform(value => !!value)
-      admin: boolean;
-
-      @Transform(value => !!value)
-      adminWithDefault: boolean = false;
-
-      lastName: string;
-
-      lastNameWithDefault: string = 'default last name';
-    }
-
-    const fromPlainUser = {};
-    const transformedUser = plainToClass(User, fromPlainUser);
-
-    expect(transformedUser).toBeInstanceOf(User);
-    expect(transformedUser).toEqual({
-      age: undefined,
-      ageWithDefault: 18,
-      firstName: undefined,
-      firstNameWithDefault: 'default first name',
-      adminWithDefault: false,
-      lastNameWithDefault: 'default last name',
-    });
-  });
 });

--- a/test/functional/default-values.spec.ts
+++ b/test/functional/default-values.spec.ts
@@ -1,0 +1,59 @@
+import { Expose, plainToClass, Transform } from '../../src';
+
+describe('expose default values', () => {
+  class User {
+    @Expose({ name: 'AGE' })
+    @Transform(({ value }) => parseInt(value, 10))
+    age: number;
+
+    @Expose({ name: 'AGE_WITH_DEFAULT' })
+    @Transform(({ value }) => parseInt(value, 10))
+    ageWithDefault?: number = 18;
+
+    @Expose({ name: 'FIRST_NAME' })
+    firstName: string;
+
+    @Expose({ name: 'FIRST_NAME_WITH_DEFAULT' })
+    firstNameWithDefault?: string = 'default first name';
+
+    @Transform(({ value }) => !!value)
+    admin: boolean;
+
+    @Transform(({ value }) => !!value)
+    adminWithDefault?: boolean = false;
+
+    lastName: string;
+
+    lastNameWithDefault?: string = 'default last name';
+  }
+
+  it('should set default value if nothing provided', () => {
+    const fromPlainUser = {};
+    const transformedUser = plainToClass(User, fromPlainUser, { exposeDefaultValues: true });
+
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toEqual({
+      age: undefined,
+      ageWithDefault: 18,
+      firstName: undefined,
+      firstNameWithDefault: 'default first name',
+      adminWithDefault: false,
+      lastNameWithDefault: 'default last name',
+    });
+  });
+
+  it('should take exposed values and ignore defaults', () => {
+    const fromPlainUser = {};
+    const transformedUser = plainToClass(User, fromPlainUser);
+
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toEqual({
+      age: NaN,
+      ageWithDefault: NaN,
+      firstName: undefined,
+      firstNameWithDefault: undefined,
+      adminWithDefault: false,
+      lastNameWithDefault: 'default last name',
+    });
+  });
+});


### PR DESCRIPTION
I think it should leave default value for unprovided fields. It worked well with `Transform` but not with `Expose`.