### PR TITLE
build: lock closed and inactive issues via GH Action

### DIFF
--- a/.github/workflows/lock-closed-issues-workflow.yml
+++ b/.github/workflows/lock-closed-issues-workflow.yml
@@ -1,0 +1,22 @@
+name: 'Lock inactive threads'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  lock:
+    name: Lock closed issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: 30
+          pr-lock-inactive-days: 30
+          issue-lock-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          pr-lock-comment: >
+            This pull request has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.


### PR DESCRIPTION
This PR adds a GH action to lock closed and inactive issues. 