### PR TITLE
fix: Fix key retrieval issue with Expose() used with Map Fields in transform

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -127,7 +127,7 @@ export class TransformOperationExecutor {
         this.recursionStack.add(value);
       }
 
-      const keys = this.getKeys(targetType as Function, value);
+      const keys = this.getKeys(targetType as Function, value, isMap);
       let newValue: any = source ? source : {};
       if (
         !source &&
@@ -390,19 +390,24 @@ export class TransformOperationExecutor {
     return meta ? meta.reflectedType : undefined;
   }
 
-  private getKeys(target: Function, object: Record<string, any>): string[] {
+  private getKeys(target: Function, object: Record<string, any>, isMap: boolean): string[] {
     // determine exclusion strategy
     let strategy = defaultMetadataStorage.getStrategy(target);
     if (strategy === 'none') strategy = this.options.strategy || 'exposeAll'; // exposeAll is default strategy
 
     // get all keys that need to expose
     let keys: any[] = [];
-    if (strategy === 'exposeAll') {
+    if (strategy === 'exposeAll' || isMap) {
       if (object instanceof Map) {
         keys = Array.from(object.keys());
       } else {
         keys = Object.keys(object);
       }
+    }
+
+    if (isMap) {
+      // expose & exclude do not apply for map keys only to fields
+      return keys;
     }
 
     if (!this.options.ignoreDecorators && target) {


### PR DESCRIPTION
### Description

It appears that when adding `@Expose()` to the nested class in conjunction with `@Type` where its tied to a Map<string,T> type does the following

```ts
    class Weapon {
      @Expose() name: string;
      @Expose() range: number;
    }

   class Player {
      @Expose() name: string
      @Expose()
      @Type(() => Weapon)
      weapons: Map<string, Weapon>;
    }

    const json = {
      name: "name",
      weapons: {
        "w1": { name: "weapon1", range: 1 },
        "w2": { name: "weapon2", range: 2}
      }
    };

    console.log(
      plainToClass(Player, json, {
        excludeExtraneousValues: false,
      })
    )
```

Result

```ts
    Player {
      name: 'name',
      weapons: Map {
        'w1' => Weapon { name: 'weapon1', range: 1 },
        'w2' => Weapon { name: 'weapon2', range: 2},
        'name' => undefined,
        'range' => undefined
      }
    }
```

- You can see that it added the Weapon properties as the string keys of the Map which doesn't seem right..
- As you can see here:

```ts
        'name' => undefined,
        'range' => undefined
```
 
- This is with Expose() added and also excludeExtraneousValues set to false
- When we set excludeExtraneousValues to true we get the abnormal behaviour that the above users is experiencing

```ts
    class Weapon {
      @Expose() name: string;
      @Expose() range: number;
    }

    class Player {
      @Expose() name: string;

      @Expose()
      @Type(() => Weapon)
      weapons: Map<string, Weapon>;
    }

    const json = {
      name: "name",
      weapons: {
        "w1": { name: "weapon1", range: 1 },
        "w2": { name: "weapon2", range: 2}
      }
    };

    console.log(
      plainToClass(Player, json, {
        excludeExtraneousValues: true,
      })
    );
  });
```

Result

```ts
    Player {
      weapons: Map { 'name' => undefined, 'range' => undefined }
    }
```

----

It turns out that the `getKeys` method in `TransformOperationExecutor.ts` was returning the wrong thing for Map fields. This change fixes that by ignoring the Expose and Exclude decorator logic and returning the object keys. 


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #319 

