### PR TITLE
Make plaintToClass available for abstract class

### DIFF
--- a/src/interfaces/class-constructor.type.ts
+++ b/src/interfaces/class-constructor.type.ts
@@ -1,3 +1,1 @@
-export type ClassConstructor<T> = {
-  new (...args: any[]): T;
-};
+export type ClassConstructor<T> = { prototype: T };


### PR DESCRIPTION
## Description
`plaintToClass` won't accept abstract class in typescript,
use `export  type ClassConstructor<T> = { prototype: T };` to
make `plaintToClass` available for abstract class

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #[issue number], fixes #[issue number]
