### PR TITLE
fix: prevent TypeError when discriminator.subTypes is not defined in @Type decorator

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -199,13 +199,13 @@ export class TransformOperationExecutor {
               if (!(value[valueKey] instanceof Array)) {
                 if (this.transformationType === TransformationType.PLAIN_TO_CLASS) {
                   type = metadata.options.discriminator.subTypes.find(subType => {
-                    if (subValue && metadata.options.discriminator.property in subValue) {
+                    if (subValue && subValue instanceof Object && metadata.options.discriminator.property in subValue) {
                       return subType.name === subValue[metadata.options.discriminator.property];
                     }
                   });
                   type === undefined ? (type = newType) : (type = type.value);
                   if (!metadata.options.keepDiscriminatorProperty) {
-                    if (subValue && metadata.options.discriminator.property in subValue) {
+                    if (subValue && subValue instanceof Object && metadata.options.discriminator.property in subValue) {
                       delete subValue[metadata.options.discriminator.property];
                     }
                   }


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ x ] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [ x ] the pull request targets the *default* branch of the repository (`develop`)
- [ x ] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [ x ] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #[issue number], fixes #[issue number]
