### PR TITLE
fix: plainToClass throws an error when a union-type member is undefined

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -1,5 +1,5 @@
 import { defaultMetadataStorage } from './storage';
-import { TypeHelpOptions, TypeOptions, ClassTransformOptions, TypeMetadata } from './interfaces';
+import { ClassTransformOptions, TypeHelpOptions, TypeMetadata, TypeOptions } from './interfaces';
 import { TransformationType } from './enums';
 import { getGlobal } from './utils';
 
@@ -214,9 +214,11 @@ export class TransformOperationExecutor {
                   type = subValue.constructor;
                 }
                 if (this.transformationType === TransformationType.CLASS_TO_PLAIN) {
-                  subValue[metadata.options.discriminator.property] = metadata.options.discriminator.subTypes.find(
-                    subType => subType.value === subValue.constructor
-                  ).name;
+                  if (subValue) {
+                    subValue[metadata.options.discriminator.property] = metadata.options.discriminator.subTypes.find(
+                      subType => subType.value === subValue.constructor
+                    ).name;
+                  }
                 }
               } else {
                 type = metadata;

--- a/test/functional/custom-transform.spec.ts
+++ b/test/functional/custom-transform.spec.ts
@@ -518,6 +518,60 @@ describe('custom transformation decorator', () => {
     }).not.toThrow();
   });
 
+  /**
+   * test-case for issue #520
+   */
+  it('should deserialize undefined union type to undefined', () => {
+    defaultMetadataStorage.clear();
+    expect(() => {
+      abstract class Hobby {
+        public name: string;
+      }
+
+      class Sports extends Hobby {
+        // Empty
+      }
+
+      class Relaxing extends Hobby {
+        // Empty
+      }
+
+      class Programming extends Hobby {
+        @Transform(({ value }) => value.toUpperCase())
+        specialAbility: string;
+      }
+
+      class Person {
+        public name: string;
+
+        @Type(() => Hobby, {
+          discriminator: {
+            property: '__type',
+            subTypes: [
+              { value: Sports, name: 'sports' },
+              { value: Relaxing, name: 'relax' },
+              { value: Programming, name: 'program' },
+            ],
+          },
+        })
+        public hobby: Hobby;
+      }
+
+      const model: Person = new Person();
+      const sport = new Sports();
+      sport.name = 'Football';
+      const program = new Programming();
+      program.name = 'typescript coding';
+      program.specialAbility = 'testing';
+      model.name = 'John Doe';
+      // NOTE: hobby remains undefined
+      model.hobby = undefined;
+      const json: any = classToPlain(model);
+      expect(json).not.toBeInstanceOf(Person);
+      expect(json.hobby).toBeUndefined();
+    }).not.toThrow();
+  });
+
   it('should transform class Person into class OtherPerson with different possibilities for type of one property (polymorphism)', () => {
     defaultMetadataStorage.clear();
     expect(() => {


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
the `transform()` function will now check if `subValue` is defined before it tries to access its `constructor` property

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- <s>documentation added or updated</s>: not applicable
- [x] I have run the project locally and verified that there are no errors: I've run `npm test`

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #520