### PR TITLE
fix: DiscriminatorDescriptor interface now accepts number, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ let album = plainToClass(Album, albumJson);
 ### Providing more than one type option[⬆](#table-of-contents)
 
 In case the nested object can be of different types, you can provide an additional options object,
-that specifies a discriminator. The discriminator option must define a `property` that holds the subtype 
+that specifies a discriminator. The discriminator option must define a `property` that holds the subtype
 name for the object and the possible `subTypes` that the nested object can converted to. A sub type
 has a `value`, that holds the constructor of the Type and the `name`, that can match with the `property`
 of the discriminator.

--- a/src/interfaces/decorator-options/type-discriminator-descriptor.interface.ts
+++ b/src/interfaces/decorator-options/type-discriminator-descriptor.interface.ts
@@ -18,7 +18,7 @@ export interface DiscriminatorDescriptor {
     /**
      * Name of the type.
      */
-    name: string;
+    name: string | number;
 
     /**
      * A class constructor which can be used to create the object.


### PR DESCRIPTION
When using an enum as `name` it works fine by adding `//@ts-ignore` but the interface didnt allow that. 

```
@ValidateNested()
  @Type(() => MyDto, {
    discriminator: {
      property: 'type',
      subTypes: [
        {value: MySubDto1, name: MyEnum.Something},
        {value: MySubDto2, name: MyEnum.SomethingOther},
      ],
    },
    keepDiscriminatorProperty: true,
  })
  cupData: MySubDto1 | MySubDto2;
```

## Description
I changed the interface to accept string OR number.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [ x the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

