### PR TITLE
Feat: extends discriminator lookup

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -1,5 +1,5 @@
 import { defaultMetadataStorage } from './storage';
-import { ClassTransformOptions, TypeHelpOptions, TypeMetadata, TypeOptions } from './interfaces';
+import { ClassTransformOptions, TypeHelpOptions, TypeMetadata } from './interfaces';
 import { TransformationType } from './enums';
 import { getGlobal, isPromise } from './utils';
 

--- a/src/interfaces/decorator-options/type-discriminator-descriptor.interface.ts
+++ b/src/interfaces/decorator-options/type-discriminator-descriptor.interface.ts
@@ -8,7 +8,13 @@ export interface DiscriminatorDescriptor {
   /**
    * The name of the property which holds the type information in the received object.
    */
-  property: string;
+  property: string | string[];
+
+  /**
+   * Wether the property should be lookedup in the parent object.
+   */
+  parentProperty?: boolean;
+
   /**
    * List of the available types. The transformer will try to lookup the object
    * with the same key as the value received in the defined discriminator property
@@ -18,7 +24,7 @@ export interface DiscriminatorDescriptor {
     /**
      * Name of the type.
      */
-    name: string;
+    name: string | number;
 
     /**
      * A class constructor which can be used to create the object.


### PR DESCRIPTION
## Description

I truly appreciate the possibility to have pseudo dynamic class in my models. 
Unfortunately, it's not always possible to add a new specific property to make the lookup working and moreover quite often the discriminator can already be found in the parent object.

My proposal is the following :
- add a `parentProperty` flag in `DiscriminatorDescriptor` to indicate if we should look for the discriminator in the parent
- allow `DiscriminatorDescriptor.subTypes.name` to be string or a number
- allow `DiscriminatorDescriptor.property`to be either string or string[] to provide more complex path
- create new helpers (`getDiscriminator`, `setFromDiscriminator`, `removeDiscriminator`) in `TransformOperationExecutor.ts` to delegate lookup and object updates.
- update `transform` flow when the discriminator options are provided

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors
- [ ] add extra unit tests in `custom-transform.spec`

### Fixes

fixes #857
