### PR TITLE
Distinguish bigints

### DIFF
--- a/src/interfaces/class-transformer-options.interface.ts
+++ b/src/interfaces/class-transformer-options.interface.ts
@@ -76,4 +76,12 @@ export interface ClassTransformOptions {
    * DEFAULT: `true`
    */
   exposeUnsetFields?: boolean;
+
+  /**
+   * When set to true, fields like `12345n` are treated as Numnbers. Otherwise
+   * those fields are strings.
+   *
+   * DEFAULT: `false`
+   */
+  distinguishBigInts?: boolean;
 }


### PR DESCRIPTION
## Description
Option 'distinguishBigInts' is added to ClassTransformOptions, while set, deserializing of bigint numberic fields (like "12345n") are converted to numbers, not strings.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors
