### PR TITLE
fix: use global scope for metadata storage

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,13 @@
 import { MetadataStorage } from './MetadataStorage';
+import { getGlobal } from './utils';
+
+const globalScope = getGlobal();
 
 /**
  * Default metadata storage is used as singleton and can be used to storage all metadatas.
  */
-export const defaultMetadataStorage = new MetadataStorage();
+if (!globalScope.classTransformerMetadataStorage) {
+  globalScope.classTransformerMetadataStorage = new MetadataStorage();
+}
+
+export const defaultMetadataStorage = globalScope.classTransformerMetadataStorage;


### PR DESCRIPTION
## Description
Currently, the type metadata are cached in `MetadataStorage` which is created `src/storage.ts` and exported. As long as this file is imported once, it works as intended. When importing (requiring) file, Node.js looks it up in the import cache so that the every file is imported only once. This however relies on consistent file names and has some caveats as covered in the [documentation](https://nodejs.org/api/modules.html#modules_module_caching_caveats). For instance file case sensitiveness or using symlinks inside node_modules. This behavior can lead to having more than one instance of `MetadataStorage` and failing to resolve the correct data types, consequently spitting up random errors.

## Solution
Taking inspiration from [class-validator](https://github.com/typestack/class-validator/blob/615931e2903cbd680bd8fe2256e8d37dd20aeb37/src/metadata/MetadataStorage.ts#L144-L152) I propose to use `global` as a place which persists through the whole lifetime and is guaranteed to create a true singleton.

In the meantime, I am publishing my own fork containing this fix at [class-transformer-global-storage](https://www.npmjs.com/package/class-transformer-global-storage)

## Caveats
This solution might cause some problems if class-transformer is transitively required by multiple libraries using different versions. First package to import class-transformer will seize the global scope and creating the (possibly outdated) singleton.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #928
