### PR TITLE
docs: fix deprecation text of deserialize() function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ export function serialize<T>(object: T | T[], options?: ClassTransformOptions): 
  *
  * @deprecated This function is being removed. Please use the following instead:
  * ```
- * instanceToClass(cls, JSON.parse(json), options)
+ * plainToInstance(cls, JSON.parse(json), options)
  * ```
  */
 export function deserialize<T>(cls: ClassConstructor<T>, json: string, options?: ClassTransformOptions): T {
@@ -150,7 +150,7 @@ export function deserialize<T>(cls: ClassConstructor<T>, json: string, options?:
  *
  * @deprecated This function is being removed. Please use the following instead:
  * ```
- * JSON.parse(json).map(value => instanceToClass(cls, value, options))
+ * JSON.parse(json).map(value => plainToInstance(cls, value, options))
  * ```
  *
  */


### PR DESCRIPTION
## Description
The deprecation text of the `deserialize` function says that we should now use the `instanceToClass` function instead but there's no `instanceToClass` function in the `class-transformer` package.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [ ] the code follows the established code style of the repository – **N/A**
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)  – **N/A**
- [x] documentation added or updated
- [ ] I have run the project locally and verified that there are no errors  – **N/A**

### Fixes
fixes #1019
