### PR TITLE
fix: deprecation function names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ export function serialize<T>(object: T | T[], options?: ClassTransformOptions): 
  *
  * @deprecated This function is being removed. Please use the following instead:
  * ```
- * instanceToClass(cls, JSON.parse(json), options)
+ * plainToInstance(cls, JSON.parse(json), options)
  * ```
  */
 export function deserialize<T>(cls: ClassConstructor<T>, json: string, options?: ClassTransformOptions): T {
@@ -150,7 +150,7 @@ export function deserialize<T>(cls: ClassConstructor<T>, json: string, options?:
  *
  * @deprecated This function is being removed. Please use the following instead:
  * ```
- * JSON.parse(json).map(value => instanceToClass(cls, value, options))
+ * JSON.parse(json).map(value => plainToInstance(cls, value, options))
  * ```
  *
  */


### PR DESCRIPTION
It seems to me the deprecation message for the deserialize functions were not correct.