### PR TITLE
feat: option to throw error for unknown properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Source code is available [here](https://github.com/pleerock/class-transformer-de
   - [serialize](#serialize)
   - [deserialize and deserializeArray](#deserialize-and-deserializearray)
 - [Enforcing type-safe instance](#enforcing-type-safe-instance)
-- [Throw an error for unknown properties](#throw-error-unknown-properties)
+- [Throw error for unknown properties](#throw-error-for-unknown-properties)
 - [Working with nested objects](#working-with-nested-objects)
   - [Providing more than one type option](#providing-more-than-one-type-option)
 - [Exposing getters and method return values](#exposing-getters-and-method-return-values)
@@ -340,7 +340,7 @@ console.log(plainToClass(User, fromPlainUser, { excludeExtraneousValues: true })
 // }
 ```
 
-## Throw an error for unknown properties[⬆](#throw-error-unknown-properties)
+## Throw error for unknown properties[⬆](#table-of-contents)
 
 The default behaviour of the `plainToClass` method is to set _all_ properties from the plain object,
 even those which are not specified in the class.
@@ -364,33 +364,6 @@ const fromPlainUser = {
 console.log(plainToClass(User, fromPlainUser, { throwErrorExtraneousValues: true }));
 
 // An error object will be thrown, because the 'unknownProp' is not defined in the User class.
-```
-
-If this behaviour does not suit your needs, you can use the `excludeExtraneousValues` option
-in the `plainToClass` method while _exposing all your class properties_ as a requirement.
-
-```typescript
-import { Expose, plainToClass } from 'class-transformer';
-
-class User {
-  @Expose() id: number;
-  @Expose() firstName: string;
-  @Expose() lastName: string;
-}
-
-const fromPlainUser = {
-  unkownProp: 'hello there',
-  firstName: 'Umed',
-  lastName: 'Khudoiberdiev',
-};
-
-console.log(plainToClass(User, fromPlainUser, { excludeExtraneousValues: true }));
-
-// User {
-//   id: undefined,
-//   firstName: 'Umed',
-//   lastName: 'Khudoiberdiev'
-// }
 ```
 
 ## Working with nested objects[⬆](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ const fromPlainUser = {
   lastName: 'Khudoiberdiev',
 };
 
-console.log(plainToClass(User, fromPlainUser, { throwErrorExtraneousValues: true }));
+plainToClass(User, fromPlainUser, { throwErrorExtraneousValues: true });
 
 // An error object will be thrown, because the 'unknownProp' is not defined in the User class.
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Source code is available [here](https://github.com/pleerock/class-transformer-de
   - [serialize](#serialize)
   - [deserialize and deserializeArray](#deserialize-and-deserializearray)
 - [Enforcing type-safe instance](#enforcing-type-safe-instance)
+- [Throw an error for unknown properties](#throw-error-unknown-properties)
 - [Working with nested objects](#working-with-nested-objects)
   - [Providing more than one type option](#providing-more-than-one-type-option)
 - [Exposing getters and method return values](#exposing-getters-and-method-return-values)
@@ -310,6 +311,59 @@ console.log(plainToClass(User, fromPlainUser));
 //   firstName: 'Umed',
 //   lastName: 'Khudoiberdiev',
 // }
+```
+
+If this behaviour does not suit your needs, you can use the `excludeExtraneousValues` option
+in the `plainToClass` method while _exposing all your class properties_ as a requirement.
+
+```typescript
+import { Expose, plainToClass } from 'class-transformer';
+
+class User {
+  @Expose() id: number;
+  @Expose() firstName: string;
+  @Expose() lastName: string;
+}
+
+const fromPlainUser = {
+  unkownProp: 'hello there',
+  firstName: 'Umed',
+  lastName: 'Khudoiberdiev',
+};
+
+console.log(plainToClass(User, fromPlainUser, { excludeExtraneousValues: true }));
+
+// User {
+//   id: undefined,
+//   firstName: 'Umed',
+//   lastName: 'Khudoiberdiev'
+// }
+```
+
+## Throw an error for unknown properties[⬆](#throw-error-unknown-properties)
+
+The default behaviour of the `plainToClass` method is to set _all_ properties from the plain object,
+even those which are not specified in the class.
+If throwErrorExtraneousValues is true, it will throw an error when unknown properties are found.
+
+```typescript
+import { plainToClass } from 'class-transformer';
+
+class User {
+  id: number;
+  firstName: string;
+  lastName: string;
+}
+
+const fromPlainUser = {
+  unknownProp: 'hello there',
+  firstName: 'Umed',
+  lastName: 'Khudoiberdiev',
+};
+
+console.log(plainToClass(User, fromPlainUser, { throwErrorExtraneousValues: true }));
+
+// An error object will be thrown, because the 'unknownProp' is not defined in the User class.
 ```
 
 If this behaviour does not suit your needs, you can use the `excludeExtraneousValues` option

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -473,11 +473,11 @@ export class TransformOperationExecutor {
         keys = exposedProperties;
       } else {
         if (this.options.throwErrorExtraneousValues) {
-          let unknowns = keys.filter(k => {
+          const unknowns: string[] = keys.filter(k => {
             return !exposedProperties.includes(k);
           });
           if (unknowns.length > 0) {
-            throw new Error('Unknown properties found. [' + unknowns + ']');
+            throw new Error(`Unknown properties found. [${unknowns.toString()}]`);
           }
         }
         keys = keys.concat(exposedProperties);

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -472,6 +472,14 @@ export class TransformOperationExecutor {
       if (this.options.excludeExtraneousValues) {
         keys = exposedProperties;
       } else {
+        if (this.options.throwErrorExtraneousValues) {
+          let unknowns = keys.filter(k => {
+            return !exposedProperties.includes(k);
+          });
+          if (unknowns.length > 0) {
+            throw new Error('Unknown properties found. [' + unknowns + ']');
+          }
+        }
         keys = keys.concat(exposedProperties);
       }
 

--- a/src/constants/default-options.constant.ts
+++ b/src/constants/default-options.constant.ts
@@ -7,6 +7,7 @@ export const defaultOptions: Partial<ClassTransformOptions> = {
   enableCircularCheck: false,
   enableImplicitConversion: false,
   excludeExtraneousValues: false,
+  throwErrorExtraneousValues: false,
   excludePrefixes: undefined,
   exposeDefaultValues: false,
   exposeUnsetFields: true,

--- a/src/interfaces/class-transformer-options.interface.ts
+++ b/src/interfaces/class-transformer-options.interface.ts
@@ -19,6 +19,14 @@ export interface ClassTransformOptions {
   excludeExtraneousValues?: boolean;
 
   /**
+   * Indicates if it throws an error when extraneous properties are found.
+   *
+   * This option requires that each property on the target class has at least one `@Expose` or `@Exclude` decorator
+   * assigned from this library.
+   */
+  throwErrorExtraneousValues?: boolean;
+
+  /**
    * Only properties with given groups gonna be transformed.
    */
   groups?: string[];

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -152,6 +152,33 @@ describe('basic functionality', () => {
     });
   });
 
+  it('should throw an error if the throwErrorExtraneousValues option is set to true', () => {
+    defaultMetadataStorage.clear();
+
+    class User {
+      @Expose() id: number;
+      @Expose() firstName: string;
+      @Expose() lastName: string;
+    }
+
+    const fromPlainUser = {
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      age: 12,
+    };
+
+    const transformedUser = plainToInstance(User, fromPlainUser);
+    expect(transformedUser).toBeInstanceOf(User);
+    expect(transformedUser).toHaveProperty('age');
+    expect(transformedUser.id).toBeUndefined();
+
+    function drinkOctopus() {
+      plainToInstance(User, fromPlainUser, { throwErrorExtraneousValues: true });
+    }
+
+    expect(drinkOctopus).toThrowError(new Error('Unknown properties found. [age]'));
+  });
+
   it('should exclude all objects marked with @Exclude() decorator', () => {
     defaultMetadataStorage.clear();
 


### PR DESCRIPTION
## Description
I added a new option 'throwErrorExtraneousValues' to throw an error when it has unknown properties.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors
