### PR TITLE
Adding @Alias decorator and allow multiple @Expose decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,55 @@ export class User {
 }
 ```
 
+If you need to rename the property from or to a plain instance,
+you can use the `from` and `to` options of `@Alias`:
+
+```typescript
+import { Expose } from 'class-transformer';
+
+export class User {
+  @Expose({ name: 'uid' })
+  id: string;
+
+  firstName: string;
+
+  lastName: string;
+
+  @Alias({ from: 'secretKey', to: '__password' })
+  password: string;
+
+  @Alias({ to: 'fullName' })
+  getFullName() {
+    return this.firstName + ' ' + this.lastName;
+  }
+}
+```
+
+Using this configuration, the `User` object would accept
+the following plain object for `plainToInstance(User, ...)`:
+
+```json
+{
+  "uid": "1234",
+  "firstName": "John",
+  "lastName": "Doe",
+  "secretKey": "allYourBaseAreBelongToUs"
+}
+```
+
+Subsequently `instanceToPlain(...)` would then produce the
+following plain object:
+
+```json
+{
+  "uid": "1234",
+  "firstName": "John",
+  "lastName": "Doe",
+  "__password": "allYourBaseAreBelongToUs",
+  "fullName": "John Doe"
+}
+```
+
 ## Skipping specific properties[⬆](#table-of-contents)
 
 Sometimes you want to skip some properties during transformation.

--- a/src/MetadataStorage.ts
+++ b/src/MetadataStorage.ts
@@ -20,39 +20,49 @@ export class MetadataStorage {
   // -------------------------------------------------------------------------
 
   addTypeMetadata(metadata: TypeMetadata): void {
-    if (!this._typeMetadatas.has(metadata.target)) {
-      this._typeMetadatas.set(metadata.target, new Map<string, TypeMetadata>());
+    let properties = this._typeMetadatas.get(metadata.target);
+    if (!properties) {
+      properties = new Map<string, TypeMetadata>();
+      this._typeMetadatas.set(metadata.target, properties);
     }
-    this._typeMetadatas.get(metadata.target)!.set(metadata.propertyName, metadata);
+    properties.set(metadata.propertyName, metadata);
   }
 
   addTransformMetadata(metadata: TransformMetadata): void {
-    if (!this._transformMetadatas.has(metadata.target)) {
-      this._transformMetadatas.set(metadata.target, new Map<string, TransformMetadata[]>());
+    let properties = this._transformMetadatas.get(metadata.target);
+    if (!properties) {
+      properties = new Map<string, TransformMetadata[]>();
+      this._transformMetadatas.set(metadata.target, properties);
     }
-    const properties = this._transformMetadatas.get(metadata.target)!;
-    if (!properties.has(metadata.propertyName)) {
-      properties.set(metadata.propertyName, []);
+    let metadatas = properties.get(metadata.propertyName);
+    if (!metadatas) {
+      metadatas = [];
+      properties.set(metadata.propertyName, metadatas);
     }
-    properties.get(metadata.propertyName)!.push(metadata);
+    metadatas.push(metadata);
   }
 
   addExposeMetadata(metadata: ExposeMetadata): void {
-    if (!this._exposeMetadatas.has(metadata.target)) {
-      this._exposeMetadatas.set(metadata.target, new Map<string, ExposeMetadata[]>());
+    let properties = this._exposeMetadatas.get(metadata.target);
+    if (!properties) {
+      properties = new Map<string, ExposeMetadata[]>();
+      this._exposeMetadatas.set(metadata.target, properties);
     }
-    const properties = this._exposeMetadatas.get(metadata.target)!;
-    if (!properties.has(metadata.propertyName)) {
-      properties.set(metadata.propertyName, []);
+    let values = properties.get(metadata.propertyName);
+    if (!values) {
+      values = [];
+      properties.set(metadata.propertyName, values);
     }
-    properties.get(metadata.propertyName)!.push(metadata);
+    values.push(metadata);
   }
 
   addExcludeMetadata(metadata: ExcludeMetadata): void {
-    if (!this._excludeMetadatas.has(metadata.target)) {
-      this._excludeMetadatas.set(metadata.target, new Map<string, ExcludeMetadata>());
+    let properties = this._excludeMetadatas.get(metadata.target);
+    if (!properties) {
+      properties = new Map<string, ExcludeMetadata>();
+      this._excludeMetadatas.set(metadata.target, properties);
     }
-    this._excludeMetadatas.get(metadata.target)!.set(metadata.propertyName, metadata);
+    properties.set(metadata.propertyName, metadata);
   }
 
   // -------------------------------------------------------------------------
@@ -159,7 +169,7 @@ export class MetadataStorage {
 
         return true;
       })
-      .map(metadata => metadata.propertyName!);
+      .map(metadata => metadata.propertyName as string);
   }
 
   getExcludedProperties(target: Function, transformationType: TransformationType): string[] {
@@ -181,7 +191,7 @@ export class MetadataStorage {
 
         return true;
       })
-      .map(metadata => metadata.propertyName!);
+      .map(metadata => metadata.propertyName as string);
   }
 
   clear(): void {
@@ -282,7 +292,7 @@ export class MetadataStorage {
       const ancestorMetadataMap = metadatas.get(ancestor);
       if (ancestorMetadataMap) {
         if (ancestorMetadataMap.has(propertyName)) {
-          metadataFromAncestorsTarget.push(...ancestorMetadataMap.get(propertyName)!);
+          metadataFromAncestorsTarget.push(...(ancestorMetadataMap.get(propertyName) as T[]));
         }
       }
     }

--- a/src/MetadataStorage.ts
+++ b/src/MetadataStorage.ts
@@ -11,8 +11,8 @@ export class MetadataStorage {
 
   private _typeMetadatas = new Map<Function, Map<string, TypeMetadata>>();
   private _transformMetadatas = new Map<Function, Map<string, TransformMetadata[]>>();
-  private _exposeMetadatas = new Map<Function, Map<string, ExposeMetadata>>();
-  private _excludeMetadatas = new Map<Function, Map<string, ExcludeMetadata>>();
+  private _exposeMetadatas = new Map<Function, Map<string | undefined, ExposeMetadata[]>>();
+  private _excludeMetadatas = new Map<Function, Map<string | undefined, ExcludeMetadata>>();
   private _ancestorsMap = new Map<Function, Function[]>();
 
   // -------------------------------------------------------------------------
@@ -23,31 +23,36 @@ export class MetadataStorage {
     if (!this._typeMetadatas.has(metadata.target)) {
       this._typeMetadatas.set(metadata.target, new Map<string, TypeMetadata>());
     }
-    this._typeMetadatas.get(metadata.target).set(metadata.propertyName, metadata);
+    this._typeMetadatas.get(metadata.target)!.set(metadata.propertyName, metadata);
   }
 
   addTransformMetadata(metadata: TransformMetadata): void {
     if (!this._transformMetadatas.has(metadata.target)) {
       this._transformMetadatas.set(metadata.target, new Map<string, TransformMetadata[]>());
     }
-    if (!this._transformMetadatas.get(metadata.target).has(metadata.propertyName)) {
-      this._transformMetadatas.get(metadata.target).set(metadata.propertyName, []);
+    const properties = this._transformMetadatas.get(metadata.target)!;
+    if (!properties.has(metadata.propertyName)) {
+      properties.set(metadata.propertyName, []);
     }
-    this._transformMetadatas.get(metadata.target).get(metadata.propertyName).push(metadata);
+    properties.get(metadata.propertyName)!.push(metadata);
   }
 
   addExposeMetadata(metadata: ExposeMetadata): void {
     if (!this._exposeMetadatas.has(metadata.target)) {
-      this._exposeMetadatas.set(metadata.target, new Map<string, ExposeMetadata>());
+      this._exposeMetadatas.set(metadata.target, new Map<string, ExposeMetadata[]>());
     }
-    this._exposeMetadatas.get(metadata.target).set(metadata.propertyName, metadata);
+    const properties = this._exposeMetadatas.get(metadata.target)!;
+    if (!properties.has(metadata.propertyName)) {
+      properties.set(metadata.propertyName, []);
+    }
+    properties.get(metadata.propertyName)!.push(metadata);
   }
 
   addExcludeMetadata(metadata: ExcludeMetadata): void {
     if (!this._excludeMetadatas.has(metadata.target)) {
       this._excludeMetadatas.set(metadata.target, new Map<string, ExcludeMetadata>());
     }
-    this._excludeMetadatas.get(metadata.target).set(metadata.propertyName, metadata);
+    this._excludeMetadatas.get(metadata.target)!.set(metadata.propertyName, metadata);
   }
 
   // -------------------------------------------------------------------------
@@ -77,21 +82,44 @@ export class MetadataStorage {
     });
   }
 
-  findExcludeMetadata(target: Function, propertyName: string): ExcludeMetadata {
+  findExcludeMetadata(target: Function, propertyName: string): ExcludeMetadata | undefined {
     return this.findMetadata(this._excludeMetadatas, target, propertyName);
   }
 
-  findExposeMetadata(target: Function, propertyName: string): ExposeMetadata {
-    return this.findMetadata(this._exposeMetadatas, target, propertyName);
+  findExposeMetadata(
+    target: Function,
+    propertyName: string,
+    transformationType: TransformationType
+  ): ExposeMetadata | undefined {
+    return this.findMetadatas(this._exposeMetadatas, target, propertyName).find(metadata => {
+      if (!metadata.options) return true;
+      if (metadata.options.toClassOnly === true && metadata.options.toPlainOnly === true) return true;
+
+      if (metadata.options.toClassOnly === true) {
+        return (
+          transformationType === TransformationType.CLASS_TO_CLASS ||
+          transformationType === TransformationType.PLAIN_TO_CLASS
+        );
+      }
+      if (metadata.options.toPlainOnly === true) {
+        return transformationType === TransformationType.CLASS_TO_PLAIN;
+      }
+
+      return true;
+    });
   }
 
-  findExposeMetadataByCustomName(target: Function, name: string): ExposeMetadata {
+  findExposeMetadataByCustomName(
+    target: Function,
+    name: string,
+    transformType: TransformationType
+  ): ExposeMetadata | undefined {
     return this.getExposedMetadatas(target).find(metadata => {
       return metadata.options && metadata.options.name === name;
     });
   }
 
-  findTypeMetadata(target: Function, propertyName: string): TypeMetadata {
+  findTypeMetadata(target: Function, propertyName: string): TypeMetadata | undefined {
     return this.findMetadata(this._typeMetadatas, target, propertyName);
   }
 
@@ -105,7 +133,7 @@ export class MetadataStorage {
   }
 
   getExposedMetadatas(target: Function): ExposeMetadata[] {
-    return this.getMetadata(this._exposeMetadatas, target);
+    return this.getMetadatas(this._exposeMetadatas, target);
   }
 
   getExcludedMetadatas(target: Function): ExcludeMetadata[] {
@@ -115,6 +143,7 @@ export class MetadataStorage {
   getExposedProperties(target: Function, transformationType: TransformationType): string[] {
     return this.getExposedMetadatas(target)
       .filter(metadata => {
+        if (!metadata.propertyName) return false;
         if (!metadata.options) return true;
         if (metadata.options.toClassOnly === true && metadata.options.toPlainOnly === true) return true;
 
@@ -130,12 +159,13 @@ export class MetadataStorage {
 
         return true;
       })
-      .map(metadata => metadata.propertyName);
+      .map(metadata => metadata.propertyName!);
   }
 
   getExcludedProperties(target: Function, transformationType: TransformationType): string[] {
     return this.getExcludedMetadatas(target)
       .filter(metadata => {
+        if (!metadata.propertyName) return false;
         if (!metadata.options) return true;
         if (metadata.options.toClassOnly === true && metadata.options.toPlainOnly === true) return true;
 
@@ -151,7 +181,7 @@ export class MetadataStorage {
 
         return true;
       })
-      .map(metadata => metadata.propertyName);
+      .map(metadata => metadata.propertyName!);
   }
 
   clear(): void {
@@ -165,12 +195,12 @@ export class MetadataStorage {
   // Private Methods
   // -------------------------------------------------------------------------
 
-  private getMetadata<T extends { target: Function; propertyName: string }>(
-    metadatas: Map<Function, Map<string, T>>,
+  private getMetadata<T extends { target: Function; propertyName: string | undefined }>(
+    metadatas: Map<Function, Map<string | undefined, T>>,
     target: Function
   ): T[] {
     const metadataFromTargetMap = metadatas.get(target);
-    let metadataFromTarget: T[];
+    let metadataFromTarget: T[] | undefined = undefined;
     if (metadataFromTargetMap) {
       metadataFromTarget = Array.from(metadataFromTargetMap.values()).filter(meta => meta.propertyName !== undefined);
     }
@@ -187,11 +217,37 @@ export class MetadataStorage {
     return metadataFromAncestors.concat(metadataFromTarget || []);
   }
 
-  private findMetadata<T extends { target: Function; propertyName: string }>(
-    metadatas: Map<Function, Map<string, T>>,
+  private getMetadatas<T extends { target: Function; propertyName: string | undefined }>(
+    metadatas: Map<Function, Map<string | undefined, T[]>>,
+    target: Function
+  ): T[] {
+    const metadataFromTargetMap = metadatas.get(target);
+    let metadataFromTarget: T[] | undefined = undefined;
+    if (metadataFromTargetMap) {
+      metadataFromTarget = Array.from(metadataFromTargetMap.values()).reduce(
+        (acc, values) => acc.concat(values.filter(meta => meta.propertyName !== undefined)),
+        []
+      );
+    }
+    const metadataFromAncestors: T[] = [];
+    for (const ancestor of this.getAncestors(target)) {
+      const ancestorMetadataMap = metadatas.get(ancestor);
+      if (ancestorMetadataMap) {
+        const metadataFromAncestor = Array.from(ancestorMetadataMap.values()).reduce(
+          (acc, values) => acc.concat(values.filter(meta => meta.propertyName !== undefined)),
+          []
+        );
+        metadataFromAncestors.push(...metadataFromAncestor);
+      }
+    }
+    return metadataFromAncestors.concat(metadataFromTarget || []);
+  }
+
+  private findMetadata<T extends { target: Function; propertyName: string | undefined }>(
+    metadatas: Map<Function, Map<string | undefined, T>>,
     target: Function,
     propertyName: string
-  ): T {
+  ): T | undefined {
     const metadataFromTargetMap = metadatas.get(target);
     if (metadataFromTargetMap) {
       const metadataFromTarget = metadataFromTargetMap.get(propertyName);
@@ -211,13 +267,13 @@ export class MetadataStorage {
     return undefined;
   }
 
-  private findMetadatas<T extends { target: Function; propertyName: string }>(
-    metadatas: Map<Function, Map<string, T[]>>,
+  private findMetadatas<T extends { target: Function; propertyName: string | undefined }>(
+    metadatas: Map<Function, Map<string | undefined, T[]>>,
     target: Function,
     propertyName: string
   ): T[] {
     const metadataFromTargetMap = metadatas.get(target);
-    let metadataFromTarget: T[];
+    let metadataFromTarget: T[] | undefined = undefined;
     if (metadataFromTargetMap) {
       metadataFromTarget = metadataFromTargetMap.get(propertyName);
     }
@@ -226,7 +282,7 @@ export class MetadataStorage {
       const ancestorMetadataMap = metadatas.get(ancestor);
       if (ancestorMetadataMap) {
         if (ancestorMetadataMap.has(propertyName)) {
-          metadataFromAncestorsTarget.push(...ancestorMetadataMap.get(propertyName));
+          metadataFromAncestorsTarget.push(...ancestorMetadataMap.get(propertyName)!);
         }
       }
     }
@@ -249,6 +305,6 @@ export class MetadataStorage {
       }
       this._ancestorsMap.set(target, ancestors);
     }
-    return this._ancestorsMap.get(target);
+    return this._ancestorsMap.get(target) || [];
   }
 }

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -170,12 +170,16 @@ export class TransformOperationExecutor {
         }
 
         const valueKey = key;
-        let newValueKey = key,
-          propertyName = key;
+        let newValueKey = key;
+        let propertyName = key;
         if (!this.options.ignoreDecorators && targetType) {
           if (this.transformationType === TransformationType.PLAIN_TO_CLASS) {
-            const exposeMetadata = defaultMetadataStorage.findExposeMetadataByCustomName(targetType as Function, key);
-            if (exposeMetadata) {
+            const exposeMetadata = defaultMetadataStorage.findExposeMetadataByCustomName(
+              targetType as Function,
+              key,
+              this.transformationType
+            );
+            if (exposeMetadata?.propertyName) {
               propertyName = exposeMetadata.propertyName;
               newValueKey = exposeMetadata.propertyName;
             }
@@ -183,7 +187,11 @@ export class TransformOperationExecutor {
             this.transformationType === TransformationType.CLASS_TO_PLAIN ||
             this.transformationType === TransformationType.CLASS_TO_CLASS
           ) {
-            const exposeMetadata = defaultMetadataStorage.findExposeMetadata(targetType as Function, key);
+            const exposeMetadata = defaultMetadataStorage.findExposeMetadata(
+              targetType as Function,
+              key,
+              this.transformationType
+            );
             if (exposeMetadata && exposeMetadata.options && exposeMetadata.options.name) {
               newValueKey = exposeMetadata.options.name;
             }
@@ -461,7 +469,7 @@ export class TransformOperationExecutor {
       let exposedProperties = defaultMetadataStorage.getExposedProperties(target, this.transformationType);
       if (this.transformationType === TransformationType.PLAIN_TO_CLASS) {
         exposedProperties = exposedProperties.map(key => {
-          const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key);
+          const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key, this.transformationType);
           if (exposeMetadata && exposeMetadata.options && exposeMetadata.options.name) {
             return exposeMetadata.options.name;
           }
@@ -486,7 +494,7 @@ export class TransformOperationExecutor {
       // apply versioning options
       if (this.options.version !== undefined) {
         keys = keys.filter(key => {
-          const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key);
+          const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key, this.transformationType);
           if (!exposeMetadata || !exposeMetadata.options) return true;
 
           return this.checkVersion(exposeMetadata.options.since, exposeMetadata.options.until);
@@ -496,14 +504,14 @@ export class TransformOperationExecutor {
       // apply grouping options
       if (this.options.groups && this.options.groups.length) {
         keys = keys.filter(key => {
-          const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key);
+          const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key, this.transformationType);
           if (!exposeMetadata || !exposeMetadata.options) return true;
 
           return this.checkGroups(exposeMetadata.options.groups);
         });
       } else {
         keys = keys.filter(key => {
-          const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key);
+          const exposeMetadata = defaultMetadataStorage.findExposeMetadata(target, key, this.transformationType);
           return (
             !exposeMetadata ||
             !exposeMetadata.options ||

--- a/src/decorators/alias.decorator.ts
+++ b/src/decorators/alias.decorator.ts
@@ -1,5 +1,5 @@
 import { defaultMetadataStorage } from '../storage';
-import { ExposeOptions } from '../interfaces';
+import { AliasOptions } from '../interfaces';
 
 /**
  * Marks the given class or property as included. By default the property is included in both
@@ -8,7 +8,7 @@ import { ExposeOptions } from '../interfaces';
  *
  * Can be applied to class definitions and properties.
  */
-export function Expose(options: ExposeOptions = {}): PropertyDecorator & ClassDecorator {
+export function Alias(options: AliasOptions = {}): PropertyDecorator & ClassDecorator {
   /**
    * NOTE: The `propertyName` property must be marked as optional because
    * this decorator used both as a class and a property decorator and the
@@ -16,15 +16,15 @@ export function Expose(options: ExposeOptions = {}): PropertyDecorator & ClassDe
    * decorator only receives one parameter.
    */
   return function (object: any, propertyName?: string | Symbol): void {
-    const metadata = {
+    defaultMetadataStorage.addExposeMetadata({
       target: object instanceof Function ? object : object.constructor,
       propertyName: propertyName as string,
-      options: {
-        ...options,
-        name: options.name || (propertyName as string),
-      },
-    };
-
-    defaultMetadataStorage.addExposeMetadata(metadata);
+      options: { name: options.from || (propertyName as string), toClassOnly: true },
+    });
+    defaultMetadataStorage.addExposeMetadata({
+      target: object instanceof Function ? object : object.constructor,
+      propertyName: propertyName as string,
+      options: { name: options.to || (propertyName as string), toPlainOnly: true },
+    });
   };
 }

--- a/src/decorators/expose.decorator.ts
+++ b/src/decorators/expose.decorator.ts
@@ -16,10 +16,12 @@ export function Expose(options: ExposeOptions = {}): PropertyDecorator & ClassDe
    * decorator only receives one parameter.
    */
   return function (object: any, propertyName?: string | Symbol): void {
-    defaultMetadataStorage.addExposeMetadata({
+    const metadata = {
       target: object instanceof Function ? object : object.constructor,
       propertyName: propertyName as string,
       options,
-    });
+    };
+
+    defaultMetadataStorage.addExposeMetadata(metadata);
   };
 }

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,5 +1,6 @@
 export * from './exclude.decorator';
 export * from './expose.decorator';
+export * from './alias.decorator';
 export * from './transform-instance-to-instance.decorator';
 export * from './transform-instance-to-plain.decorator';
 export * from './transform-plain-to-instance.decorator';

--- a/src/interfaces/decorator-options/alias-options.interface.ts
+++ b/src/interfaces/decorator-options/alias-options.interface.ts
@@ -1,0 +1,13 @@
+/**
+ * Possible transformation options for the @Alias decorator.
+ */
+export interface AliasOptions {
+  /**
+   * Name of property on the source object to read from
+   */
+  from?: string;
+  /**
+   * Name of property on the target object to expose as
+   */
+  to?: string;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,5 +1,6 @@
-export * from './decorator-options/expose-options.interface';
 export * from './decorator-options/exclude-options.interface';
+export * from './decorator-options/expose-options.interface';
+export * from './decorator-options/alias-options.interface';
 export * from './decorator-options/transform-options.interface';
 export * from './decorator-options/type-discriminator-descriptor.interface';
 export * from './decorator-options/type-options.interface';

--- a/test/functional/transformation-option.spec.ts
+++ b/test/functional/transformation-option.spec.ts
@@ -80,7 +80,7 @@ describe('filtering by transformation option', () => {
     });
   });
 
-  it('@Expose with toClassOnly set to true then it should be excluded only during instanceToPlain and classToPlainFromExist operations', () => {
+  it('@Expose with toClassOnly set to true and a name then it should be exposed renamed when transformed to instance', () => {
     defaultMetadataStorage.clear();
 
     @Exclude()
@@ -91,7 +91,7 @@ describe('filtering by transformation option', () => {
       @Expose()
       lastName: string;
 
-      @Expose({ toClassOnly: true })
+      @Expose({ name: 'pwd', toClassOnly: true })
       password: string;
     }
 
@@ -103,7 +103,7 @@ describe('filtering by transformation option', () => {
     const plainUser = {
       firstName: 'Umed',
       lastName: 'Khudoiberdiev',
-      password: 'imnosuperman',
+      pwd: 'imnosuperman',
     };
 
     const plainedUser = instanceToPlain(user);
@@ -121,7 +121,7 @@ describe('filtering by transformation option', () => {
     });
   });
 
-  it('@Expose with toPlainOnly set to true then it should be excluded only during instanceToPlain and classToPlainFromExist operations', () => {
+  it('@Expose with toPlainOnly set to true and a name then it should be exposed renamed when transformed to plain', () => {
     defaultMetadataStorage.clear();
 
     @Exclude()
@@ -132,7 +132,7 @@ describe('filtering by transformation option', () => {
       @Expose()
       lastName: string;
 
-      @Expose({ toPlainOnly: true })
+      @Expose({ name: 'pwd', toPlainOnly: true })
       password: string;
     }
 
@@ -151,7 +151,7 @@ describe('filtering by transformation option', () => {
     expect(plainedUser).toEqual({
       firstName: 'Umed',
       lastName: 'Khudoiberdiev',
-      password: 'imnosuperman',
+      pwd: 'imnosuperman',
     });
 
     const classedUser = plainToInstance(User, plainUser);
@@ -159,6 +159,49 @@ describe('filtering by transformation option', () => {
     expect(classedUser).toEqual({
       firstName: 'Umed',
       lastName: 'Khudoiberdiev',
+    });
+  });
+
+  it('@Expose with toPlainOnly set to true and a name plus another @Expose with toClassOnly set to true and a name then it should be renamed appropriatly based on operation type', () => {
+    defaultMetadataStorage.clear();
+
+    @Exclude()
+    class User {
+      @Expose()
+      firstName: string;
+
+      @Expose()
+      lastName: string;
+
+      @Expose({ name: 'toPlainPassword', toPlainOnly: true })
+      @Expose({ name: 'toClassPassword', toClassOnly: true })
+      password: string;
+    }
+
+    const user = new User();
+    user.firstName = 'Umed';
+    user.lastName = 'Khudoiberdiev';
+    user.password = 'imnosuperman';
+
+    const plainUser = {
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      toClassPassword: 'imnosuperman',
+    };
+
+    const plainedUser = instanceToPlain(user);
+    expect(plainedUser).toEqual({
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      toPlainPassword: 'imnosuperman',
+    });
+
+    const classedUser = plainToInstance(User, plainUser);
+    expect(classedUser).toBeInstanceOf(User);
+    expect(classedUser).toEqual({
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      password: 'imnosuperman',
     });
   });
 

--- a/test/functional/transformation-option.spec.ts
+++ b/test/functional/transformation-option.spec.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import { instanceToPlain, plainToInstance } from '../../src/index';
 import { defaultMetadataStorage } from '../../src/storage';
-import { Exclude, Expose } from '../../src/decorators';
+import { Alias, Exclude, Expose } from '../../src/decorators';
 
 describe('filtering by transformation option', () => {
   it('@Exclude with toPlainOnly set to true then it should be excluded only during instanceToPlain and classToPlainFromExist operations', () => {
@@ -173,7 +173,7 @@ describe('filtering by transformation option', () => {
       @Expose()
       lastName: string;
 
-      @Expose({ name: 'toPlainPassword', toPlainOnly: true })
+      @Expose({ toPlainOnly: true })
       @Expose({ name: 'toClassPassword', toClassOnly: true })
       password: string;
     }
@@ -193,7 +193,7 @@ describe('filtering by transformation option', () => {
     expect(plainedUser).toEqual({
       firstName: 'Umed',
       lastName: 'Khudoiberdiev',
-      toPlainPassword: 'imnosuperman',
+      password: 'imnosuperman',
     });
 
     const classedUser = plainToInstance(User, plainUser);
@@ -202,6 +202,94 @@ describe('filtering by transformation option', () => {
       firstName: 'Umed',
       lastName: 'Khudoiberdiev',
       password: 'imnosuperman',
+    });
+  });
+
+  it('@Alias with className only should only rename property when converted to plain', () => {
+    defaultMetadataStorage.clear();
+
+    @Exclude()
+    class User {
+      @Alias({ to: 'first_name' })
+      firstName: string;
+    }
+
+    const user = new User();
+    user.firstName = 'Umed';
+
+    const plainUser = {
+      firstName: 'Umed',
+      first_name: 'WRONG',
+    };
+
+    const plainedUser = instanceToPlain(user);
+    expect(plainedUser).toEqual({
+      first_name: 'Umed',
+    });
+
+    const classedUser = plainToInstance(User, plainUser);
+    expect(classedUser).toBeInstanceOf(User);
+    expect(classedUser).toEqual({
+      firstName: 'Umed',
+    });
+  });
+
+  it('@Alias with className only should only rename property when converted to plain', () => {
+    defaultMetadataStorage.clear();
+
+    @Exclude()
+    class User {
+      @Alias({ from: 'first_name' })
+      firstName: string;
+    }
+
+    const user = new User();
+    user.firstName = 'Umed';
+
+    const plainUser = {
+      first_name: 'Umed',
+      firstName: 'WRONG',
+    };
+
+    const plainedUser = instanceToPlain(user);
+    expect(plainedUser).toEqual({
+      firstName: 'Umed',
+    });
+
+    const classedUser = plainToInstance(User, plainUser);
+    expect(classedUser).toBeInstanceOf(User);
+    expect(classedUser).toEqual({
+      firstName: 'Umed',
+    });
+  });
+
+  it('@Alias with both className and plainName should rename property on transform', () => {
+    defaultMetadataStorage.clear();
+
+    @Exclude()
+    class User {
+      @Alias({ from: 'user_reference', to: 'userReference' })
+      reference: string;
+    }
+
+    const user = new User();
+    user.reference = 'userRef';
+
+    const plainUser = {
+      user_reference: 'userRef',
+      userReference: 'WRONG',
+      reference: 'WRONG',
+    };
+
+    const plainedUser = instanceToPlain(user);
+    expect(plainedUser).toEqual({
+      userReference: 'userRef',
+    });
+
+    const classedUser = plainToInstance(User, plainUser);
+    expect(classedUser).toBeInstanceOf(User);
+    expect(classedUser).toEqual({
+      reference: 'userRef',
     });
   });
 


### PR DESCRIPTION
## Description
Thank you for this amazing library 🚀

It has been [discussed](https://github.com/typestack/class-transformer/issues/677) several [times](https://github.com/typestack/class-transformer/issues/121) (sometimes with some [confusion](https://github.com/typestack/class-transformer/issues/366)): in some scenarios, being able to rename a property only when importing or exporting it can be useful.

For instance, I am reading rows from a file in a format A sent by a third party, then convert it to an object in my TS code. It might be logged or stored in a file in another format B later on.
One of the field is named `part_or_item_number` in the format A, which is then converted to `partRef` in my JS object.

### TLDR
`plainToInstance` should accept this object:
```json
{
  "part_or_item_number": "part1234"
}
```

The property should be referenced as follow in the code:
```typescript
findPart(myObj.partRef)
```

And `instanceToPlain` should then produce the following:
```json
{
  "partRef": "part1234"
}
```
___

One would quickly suggest to use `@Expose({ name: 'part_or_item_number' })`, however it would also expose the property under the name `part_or_item_number` when using `instanceToPlain`.

Adding the option `toClassOnly: true` is not cutting it either as it would then hide the property when using `instanceToPlain`.

Another suggestion seen in [one of the thread linked earlier](https://github.com/typestack/class-transformer/issues/366) is to use two `@Expose`:
```typescript
...
  @Expose({ name: 'part_or_item_number', toClassOnly: true })
  @Expose({ toPlainOnly: true })
  partRef: string;
...
```
While it's a pretty neat idea, it simply doesn't work in the current state, as the last `@Expose` will always replace the previous ones.
___

This PR introduces two changes:
* Allow the previous sample of code to work as described
* Introduce an `Alias` decorator to reduce boilerplate in that scenario, using `@Expose` behind the scene to reduce duplication

The code above could be rewritten as the following with the same expected behaviour:
```typescript
...
  @Alias({ from: 'part_or_item_number' })
  partRef: string;
...
```

There is also a slight rewriting of the map manipulation code in `MetadataStorage.ts`. I'm fine reverting it but it greatly improved the readability for me.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #677, fixes #121, fixes #366
