### PR TITLE
feat: Add symbols support for objects

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -438,6 +438,10 @@ export class TransformOperationExecutor {
         keys = Array.from(object.keys());
       } else {
         keys = Object.keys(object);
+        // Object.getOwnPropertySymbols is not supported in Internet Explorer
+        if (typeof Object.getOwnPropertySymbols !== 'undefined') {
+          keys = [...keys, ...Object.getOwnPropertySymbols(object)];
+        }
       }
     }
 

--- a/test/functional/transformer-method.spec.ts
+++ b/test/functional/transformer-method.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import { defaultMetadataStorage } from '../../src/storage';
+import { plainToClass } from '../../src/index';
 import {
   Exclude,
   Expose,
@@ -252,5 +253,21 @@ describe('transformer methods decorator', () => {
     };
 
     expect(resultV1).toEqual(plainUserV1);
+  });
+
+  it('should expose symbols', () => {
+    defaultMetadataStorage.clear();
+
+    const symbolField = Symbol('symbolField');
+    class ObjectId {
+      [symbolField]: string;
+    }
+
+    const plain = {
+      [symbolField]: 'id',
+    };
+
+    const obj = plainToClass(ObjectId, plain);
+    expect(obj[symbolField]).toBe('id');
   });
 });


### PR DESCRIPTION
## Description
Fixed issue for incomplete cloning objects in plainToClass.
Added support for objects having symbols as keys. This is important for cases like ObjectId in Mongod/Mongoose.

This issue was mentioned in https://github.com/typestack/class-transformer/issues/494, #1165 
It was kind of fixed there by copying a reference to original object (not cloning object), but later fix was reverted.

Here is the fix using current cloning strategy.

## Checklist
- [X] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [X] the pull request targets the *default* branch of the repository (`develop`)
- [X] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [X] tests are added for the changes I made (if any source code was modified)
- [X] documentation added or updated
- [X] I have run the project locally and verified that there are no errors

### Fixes
fixes #1165