### PR TITLE
fix: lookup up property descriptors on the prototype

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -295,7 +295,7 @@ export class TransformOperationExecutor {
 
         // if newValue is a source object that has method that match newKeyName then skip it
         if (newValue.constructor.prototype) {
-          const descriptor = Object.getOwnPropertyDescriptor(newValue.constructor.prototype, newValueKey);
+          const descriptor = this.getPropertyDescriptor(newValue.constructor.prototype, newValueKey);
           if (
             (this.transformationType === TransformationType.PLAIN_TO_CLASS ||
               this.transformationType === TransformationType.CLASS_TO_CLASS) &&
@@ -543,5 +543,12 @@ export class TransformOperationExecutor {
     if (!groups) return true;
 
     return this.options.groups.some(optionGroup => groups.includes(optionGroup));
+  }
+
+  private getPropertyDescriptor(obj: any, key: PropertyKey): PropertyDescriptor | undefined {
+    const prototype = Object.getPrototypeOf(obj);
+    return prototype
+      ? Object.getOwnPropertyDescriptor(obj, key) || this.getPropertyDescriptor(prototype, key)
+      : undefined;
   }
 }

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -546,9 +546,10 @@ export class TransformOperationExecutor {
   }
 
   private getPropertyDescriptor(obj: any, key: PropertyKey): PropertyDescriptor | undefined {
+    const descriptor = Object.getOwnPropertyDescriptor(obj, key);
+    if (descriptor) return descriptor;
+
     const prototype = Object.getPrototypeOf(obj);
-    return prototype
-      ? Object.getOwnPropertyDescriptor(obj, key) || this.getPropertyDescriptor(prototype, key)
-      : undefined;
+    return prototype ? this.getPropertyDescriptor(prototype, key) : undefined;
   }
 }

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -1664,6 +1664,55 @@ describe('basic functionality', () => {
     expect(transformedUser).toEqual(likeUser);
   });
 
+  it('should expose inherited method and accessors that have @Expose()', () => {
+    class User {
+      firstName: string;
+      lastName: string;
+
+      @Expose()
+      get name() {
+        return this.firstName + ' ' + this.lastName;
+      }
+
+      @Expose()
+      getName() {
+        return this.firstName + ' ' + this.lastName;
+      }
+    }
+    class Programmer extends User {
+      language: string;
+    }
+
+    const programmer = new Programmer();
+    programmer.firstName = 'Umed';
+    programmer.lastName = 'Khudoiberdiev';
+    programmer.language = 'en';
+
+    const fromPlainProgrammer = {
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      language: 'en',
+    };
+
+    const plainProgrammer: any = instanceToPlain(programmer);
+    expect(plainProgrammer).not.toBeInstanceOf(Programmer);
+    expect(plainProgrammer).toEqual({
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      language: 'en',
+      name: 'Umed Khudoiberdiev',
+      getName: 'Umed Khudoiberdiev',
+    });
+
+    const transformedProgrammer = plainToInstance(Programmer, fromPlainProgrammer);
+    expect(transformedProgrammer).toBeInstanceOf(Programmer);
+    const likeProgrammer = new Programmer();
+    likeProgrammer.firstName = 'Umed';
+    likeProgrammer.lastName = 'Khudoiberdiev';
+    likeProgrammer.language = 'en';
+    expect(transformedProgrammer).toEqual(likeProgrammer);
+  });
+
   it('should transform array', () => {
     defaultMetadataStorage.clear();
 

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -872,10 +872,18 @@ describe('basic functionality', () => {
       uploadDate: Date;
     }
 
-    class User {
-      id: number;
+    class Person {
       firstName: string;
       lastName: string;
+
+      @Expose()
+      get name() {
+        return this.firstName + ' ' + this.lastName;
+      }
+    }
+
+    class User extends Person {
+      id: number;
 
       @Exclude()
       password: string;
@@ -915,6 +923,7 @@ describe('basic functionality', () => {
     const transformedUser = plainToInstance(User, fromPlainUser);
     expect(transformedUser).toBeInstanceOf(User);
     expect(transformedUser.photo).toBeInstanceOf(Photo);
+    expect(transformedUser.name).toEqual('Umed Khudoiberdiev');
     expect(transformedUser).toEqual({
       firstName: 'Umed',
       lastName: 'Khudoiberdiev',
@@ -928,6 +937,7 @@ describe('basic functionality', () => {
     const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
     expect(fromExistTransformedUser).toEqual(fromExistUser);
     expect(fromExistTransformedUser.photo).toEqual(fromExistPhoto);
+    expect(fromExistTransformedUser.name).toEqual('Umed Khudoiberdiev');
     expect(fromExistTransformedUser).toEqual({
       id: 1,
       firstName: 'Umed',
@@ -945,6 +955,7 @@ describe('basic functionality', () => {
     expect(classToClassUser.photo).toBeInstanceOf(Photo);
     expect(classToClassUser).not.toEqual(user);
     expect(classToClassUser).not.toEqual(user.photo);
+    expect(classToClassUser.name).toEqual('Umed Khudoiberdiev');
     expect(classToClassUser).toEqual({
       firstName: 'Umed',
       lastName: 'Khudoiberdiev',
@@ -961,6 +972,7 @@ describe('basic functionality', () => {
     expect(classToClassFromExistUser).not.toEqual(user);
     expect(classToClassFromExistUser).not.toEqual(user.photo);
     expect(classToClassFromExistUser).toEqual(fromExistUser);
+    expect(classToClassFromExistUser.name).toEqual('Umed Khudoiberdiev');
     expect(classToClassFromExistUser).toEqual({
       id: 1,
       firstName: 'Umed',

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -872,18 +872,10 @@ describe('basic functionality', () => {
       uploadDate: Date;
     }
 
-    class Person {
+    class User {
+      id: number;
       firstName: string;
       lastName: string;
-
-      @Expose()
-      get name() {
-        return this.firstName + ' ' + this.lastName;
-      }
-    }
-
-    class User extends Person {
-      id: number;
 
       @Exclude()
       password: string;
@@ -923,7 +915,6 @@ describe('basic functionality', () => {
     const transformedUser = plainToInstance(User, fromPlainUser);
     expect(transformedUser).toBeInstanceOf(User);
     expect(transformedUser.photo).toBeInstanceOf(Photo);
-    expect(transformedUser.name).toEqual('Umed Khudoiberdiev');
     expect(transformedUser).toEqual({
       firstName: 'Umed',
       lastName: 'Khudoiberdiev',
@@ -937,7 +928,6 @@ describe('basic functionality', () => {
     const fromExistTransformedUser = plainToClassFromExist(fromExistUser, fromPlainUser);
     expect(fromExistTransformedUser).toEqual(fromExistUser);
     expect(fromExistTransformedUser.photo).toEqual(fromExistPhoto);
-    expect(fromExistTransformedUser.name).toEqual('Umed Khudoiberdiev');
     expect(fromExistTransformedUser).toEqual({
       id: 1,
       firstName: 'Umed',
@@ -955,7 +945,6 @@ describe('basic functionality', () => {
     expect(classToClassUser.photo).toBeInstanceOf(Photo);
     expect(classToClassUser).not.toEqual(user);
     expect(classToClassUser).not.toEqual(user.photo);
-    expect(classToClassUser.name).toEqual('Umed Khudoiberdiev');
     expect(classToClassUser).toEqual({
       firstName: 'Umed',
       lastName: 'Khudoiberdiev',
@@ -972,7 +961,6 @@ describe('basic functionality', () => {
     expect(classToClassFromExistUser).not.toEqual(user);
     expect(classToClassFromExistUser).not.toEqual(user.photo);
     expect(classToClassFromExistUser).toEqual(fromExistUser);
-    expect(classToClassFromExistUser.name).toEqual('Umed Khudoiberdiev');
     expect(classToClassFromExistUser).toEqual({
       id: 1,
       firstName: 'Umed',


### PR DESCRIPTION
## Description

`Object.getOwnPropertyDescriptor` can't get the descriptor of the parent class property. Need to look up the property descriptor along the prototype chain.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
references #1257
