### PR TITLE
Fix boolean conversion from string values when enableImplicitConversion option is set to true

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -1,7 +1,7 @@
 import { defaultMetadataStorage } from './storage';
 import { ClassTransformOptions, TypeHelpOptions, TypeMetadata, TypeOptions } from './interfaces';
 import { TransformationType } from './enums';
-import { getGlobal, isPromise } from './utils';
+import { getGlobal, isPromise, toBoolean } from './utils';
 
 function instantiateArrayType(arrayType: Function): Array<any> | Set<any> {
   const array = new (arrayType as any)();
@@ -106,8 +106,9 @@ export class TransformOperationExecutor {
       if (value === null || value === undefined) return value;
       return Number(value);
     } else if (targetType === Boolean && !isMap) {
-      if (value === null || value === undefined) return value;
-      return Boolean(value);
+      // Note: Next line can safely be removed as this is being handled by util to return false if either of these two are set.
+      //if (value === null || value === undefined) return value;
+      return toBoolean(value);
     } else if ((targetType === Date || value instanceof Date) && !isMap) {
       if (value instanceof Date) {
         return new Date(value.valueOf());

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './get-global.util';
 export * from './is-promise.util';
+export * from './to-boolean.util';

--- a/src/utils/to-boolean.util.ts
+++ b/src/utils/to-boolean.util.ts
@@ -1,0 +1,29 @@
+export function toBoolean(value: any): value is Boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    return value > 0;
+  }
+  if (typeof value === 'string') {
+    value = value.toLowerCase();
+    switch (value) {
+      case 'true':
+      case 'yes':
+      case 'on':
+      case '1':
+        return true;
+      case 'false':
+      case 'no':
+      case 'off':
+      case '0':
+        return false;
+      default:
+        return false;
+    }
+  }
+  return false;
+}

--- a/test/functional/basic-functionality.spec.ts
+++ b/test/functional/basic-functionality.spec.ts
@@ -626,7 +626,7 @@ describe('basic functionality', () => {
       uuidBuffer: uuid,
       nullableString: null,
       nullableNumber: null,
-      nullableBoolean: null,
+      nullableBoolean: false,
       nullableDate: null,
       nullableBuffer: null,
     });
@@ -646,7 +646,7 @@ describe('basic functionality', () => {
       uuidBuffer: uuid,
       nullableString: null,
       nullableNumber: null,
-      nullableBoolean: null,
+      nullableBoolean: false,
       nullableDate: null,
       nullableBuffer: null,
     });
@@ -664,7 +664,7 @@ describe('basic functionality', () => {
       uuidBuffer: uuid,
       nullableString: null,
       nullableNumber: null,
-      nullableBoolean: null,
+      nullableBoolean: false,
       nullableDate: null,
       nullableBuffer: null,
     });
@@ -682,7 +682,7 @@ describe('basic functionality', () => {
       uuidBuffer: uuid,
       nullableString: null,
       nullableNumber: null,
-      nullableBoolean: null,
+      nullableBoolean: false,
       nullableDate: null,
       nullableBuffer: null,
     });
@@ -700,7 +700,7 @@ describe('basic functionality', () => {
       uuidBuffer: uuid,
       nullableString: null,
       nullableNumber: null,
-      nullableBoolean: null,
+      nullableBoolean: false,
       nullableDate: null,
       nullableBuffer: null,
     });
@@ -720,7 +720,7 @@ describe('basic functionality', () => {
       uuidBuffer: uuid,
       nullableString: null,
       nullableNumber: null,
-      nullableBoolean: null,
+      nullableBoolean: false,
       nullableDate: null,
       nullableBuffer: null,
     });

--- a/test/functional/implicit-type-declarations.spec.ts
+++ b/test/functional/implicit-type-declarations.spec.ts
@@ -142,3 +142,99 @@ describe('plainToInstance transforms built-in primitive types properly', () => {
     expect(result.boolean2).toBeFalsy();
   });
 });
+
+describe('plainToInstance transforms boolean types properly', () => {
+  defaultMetadataStorage.clear();
+
+  class Example {
+    @Type()
+    undefinedValue: boolean;
+
+    @Type()
+    nullValue: boolean;
+
+    @Type()
+    booleanTrueString: boolean;
+
+    @Type()
+    booleanFalseString: boolean;
+
+    @Type()
+    trueNumberStringValue: boolean;
+
+    @Type()
+    falseNumberStringValue: boolean;
+
+    @Type()
+    boolean: boolean;
+
+    @Type()
+    boolean2: boolean;
+
+    @Type()
+    boolean3: boolean;
+
+    @Type()
+    boolean4: boolean;
+
+    @Type()
+    onTrueString: boolean;
+
+    @Type()
+    offFalseString: boolean;
+
+    @Type()
+    booleanTrueNumber: boolean;
+
+    @Type()
+    booleanFalseNumber: boolean;
+
+    @Type()
+    falseRandomString: boolean;
+  }
+
+  const result: Example = plainToInstance(
+    Example,
+    {
+      undefinedValue: undefined,
+      nullValue: null,
+      booleanTrueString: 'true',
+      booleanFalseString: 'false',
+      trueNumberStringValue: '1',
+      falseNumberStringValue: '0',
+      boolean: 1,
+      boolean2: 0,
+      boolean3: true,
+      boolean4: false,
+      onTrueString: 'on',
+      offFalseString: 'off',
+      booleanTrueNumber: '1',
+      booleanFalseNumber: '0',
+      falseRandomString: 'some random value that needs to be false',
+    },
+    { enableImplicitConversion: true }
+  );
+  it('should recognize and convert "undefined" and "null" to false', () => {
+    expect(result.undefinedValue).toBeFalsy();
+    expect(result.nullValue).toBeFalsy();
+  });
+
+  it('should recognize and convert string to boolean', () => {
+    expect(result.booleanTrueString).toBeTruthy();
+    expect(result.booleanFalseString).toBeFalsy();
+    expect(result.trueNumberStringValue).toBeTruthy();
+    expect(result.falseNumberStringValue).toBeFalsy();
+    expect(result.onTrueString).toBeTruthy();
+    expect(result.offFalseString).toBeFalsy();
+    expect(result.booleanTrueNumber).toBeTruthy();
+    expect(result.booleanFalseNumber).toBeFalsy();
+    expect(result.falseRandomString).toBeFalsy();
+  });
+
+  it('should recognize and convert to boolean', () => {
+    expect(result.boolean).toBeTruthy();
+    expect(result.boolean2).toBeFalsy();
+    expect(result.boolean3).toBeTruthy();
+    expect(result.boolean4).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Description
This PR will extend the functionality to convert the boolean values even if provided as strings.
Flow before this PR:
`canAccess: 'false'` yields `canAccess: true`

Flow after this PR:
`canAccess: 'false'` will yield to `canAccess: false`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #1328
