### PR TITLE
feat: casting empty numberstring to null

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -104,6 +104,7 @@ export class TransformOperationExecutor {
       return String(value);
     } else if (targetType === Number && !isMap) {
       if (value === null || value === undefined) return value;
+      if (value === '') return null;
       return Number(value);
     } else if (targetType === Boolean && !isMap) {
       if (value === null || value === undefined) return value;

--- a/test/functional/implicit-type-declarations.spec.ts
+++ b/test/functional/implicit-type-declarations.spec.ts
@@ -13,6 +13,9 @@ describe('implicit type conversion', () => {
 
       @Expose()
       readonly implicitTypeString: string;
+
+      @Expose()
+      readonly implicitTypeEmptyNumber: number;
     }
 
     const result1: SimpleExample = plainToInstance(
@@ -20,6 +23,7 @@ describe('implicit type conversion', () => {
       {
         implicitTypeNumber: '100',
         implicitTypeString: 133123,
+        implicitTypeEmptyNumber: '',
       },
       { enableImplicitConversion: true }
     );
@@ -29,12 +33,13 @@ describe('implicit type conversion', () => {
       {
         implicitTypeNumber: '100',
         implicitTypeString: 133123,
+        implicitTypeEmptyNumber: '',
       },
       { enableImplicitConversion: false }
     );
 
-    expect(result1).toEqual({ implicitTypeNumber: 100, implicitTypeString: '133123' });
-    expect(result2).toEqual({ implicitTypeNumber: '100', implicitTypeString: 133123 });
+    expect(result1).toEqual({ implicitTypeNumber: 100, implicitTypeString: '133123', implicitTypeEmptyNumber: null });
+    expect(result2).toEqual({ implicitTypeNumber: '100', implicitTypeString: 133123, implicitTypeEmptyNumber: '' });
   });
 });
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
In the MVC web service, when receiving user input as object from the controller through form submit, each fields should be casted from string to suitable type.
and class-transformer returns 0 when converting empty string to number.

so, IsNotEmpty of class-validator doesn't work for number field because the number field user not input will be initialized to 0.

If class-transformer returns null when converting empty characters to numbers, then IsNotEmpty can be used for number fields as well.


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

