### PR TITLE
Fix typo (deprecation note mentioned the function which doesn't exist)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ export function serialize<T>(object: T | T[], options?: ClassTransformOptions): 
  *
  * @deprecated This function is being removed. Please use the following instead:
  * ```
- * instanceToClass(cls, JSON.parse(json), options)
+ * plainToInstance(cls, JSON.parse(json), options)
  * ```
  */
 export function deserialize<T>(cls: ClassConstructor<T>, json: string, options?: ClassTransformOptions): T {
@@ -150,7 +150,7 @@ export function deserialize<T>(cls: ClassConstructor<T>, json: string, options?:
  *
  * @deprecated This function is being removed. Please use the following instead:
  * ```
- * JSON.parse(json).map(value => instanceToClass(cls, value, options))
+ * JSON.parse(json).map(value => plainToInstance(cls, value, options))
  * ```
  *
  */


### PR DESCRIPTION
Related issue: https://github.com/typestack/class-transformer/issues/1413

## Description
<!-- A clear and concise description what these changes does. -->
The deprecation comment mentions a function name that does not exist. This PR is aimed at correcting this.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #1413
fixes #1172
fixes #1019
fixes #1349
