### PR TITLE
fix: made metadata global to prevent issues with multiple package installations

### DIFF
--- a/src/MetadataStorage.ts
+++ b/src/MetadataStorage.ts
@@ -1,5 +1,6 @@
 import { TypeMetadata, ExposeMetadata, ExcludeMetadata, TransformMetadata } from './interfaces';
 import { TransformationType } from './enums';
+import { getGlobal } from './utils';
 
 /**
  * Storage all library metadata.
@@ -251,4 +252,18 @@ export class MetadataStorage {
     }
     return this._ancestorsMap.get(target);
   }
+}
+
+/**
+ * Gets metadata storage.
+ * Metadata storage follows the best practices and stores metadata in a global variable.
+ */
+export function getMetadataStorage(): MetadataStorage {
+  const global = getGlobal();
+
+  if (!global.classTransformerMetadataStorage) {
+    global.classTransformerMetadataStorage = new MetadataStorage();
+  }
+
+  return global.classTransformerMetadataStorage;
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,6 @@
-import { MetadataStorage } from './MetadataStorage';
+import { getMetadataStorage } from './MetadataStorage';
 
 /**
  * Default metadata storage is used as singleton and can be used to storage all metadatas.
  */
-export const defaultMetadataStorage = new MetadataStorage();
+export const defaultMetadataStorage = getMetadataStorage();


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
The `MetadataStorage` object currently acts as a singleton within the module by using the `defaultMetadataStorage` constant. However, this doesn't account for the scenario in which there are _multiple_ instances of the `class-transformer` library installed; this seems to be common in two cases:
  1. _Shared libraries using `class-transformer` as a prod dependency_. If the library and its consumer are on two different versions of `class-validator` then we end up with a `MetadataStorage` object for each version installed
  3. _Shared libraries which are symlinked_ (common in monorepos using workspaces, lerna, etc). Regardless of version, if there's no dep hoisting happening you'll have an instance installed in each package

Having duplicate metadata stores can have some really subtle behavior for users. In our case we were using `class-transformer` alongside `class-validator` to validate incoming messages; because our validators were coming in from a shared library the `@Type()` decorator was silently failing its lookup, resulting in all of our nested validators failing to run.

We were made aware of this issue by the breaking change in `class-validator@0.14.0` ([changelog](https://github.com/typestack/class-validator/blob/develop/CHANGELOG.md#0140-2022-12-09)) to forbid unknown values by default. Because our objects were silently being only partially transformed to DTOs by this bug, they were being considered as an "unknown value". I imagine that this may be affecting other users as well since there's been a decent amount of chatter about this on the NestJS discord and issue boards (examples: typestack/class-validator#1873, nestjs/nest#10683)

This implementation is lifted from what was done in typestack/class-validator#265 to use a global store to avoid these conflicts.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [n/a] tests are added for the changes I made (if any source code was modified)
- [n/a] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #1043, fixes #928

**Update**: found PR #929 from 2021 which is similar but contains a lot of automatic dependency updates. This change might be easier to merge at this point so going to leave it up for one of the maintainers to decide between