### PR TITLE
add type interference to `plainToClass` / `plainToInstance`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,20 +65,20 @@ export function classToPlainFromExist<T>(
  *
  * @deprecated Function name changed, use the `plainToInstance` method instead.
  */
-export function plainToClass<T, V>(cls: ClassConstructor<T>, plain: V[], options?: ClassTransformOptions): T[];
-export function plainToClass<T, V>(cls: ClassConstructor<T>, plain: V, options?: ClassTransformOptions): T;
-export function plainToClass<T, V>(cls: ClassConstructor<T>, plain: V | V[], options?: ClassTransformOptions): T | T[] {
+export function plainToClass<T>(cls: ClassConstructor<T>, plain: T[], options?: ClassTransformOptions): T[];
+export function plainToClass<T>(cls: ClassConstructor<T>, plain: T, options?: ClassTransformOptions): T;
+export function plainToClass<T>(cls: ClassConstructor<T>, plain: T | T[], options?: ClassTransformOptions): T | T[] {
   return classTransformer.plainToInstance(cls, plain as any, options);
 }
 
 /**
  * Converts plain (literal) object to class (constructor) object. Also works with arrays.
  */
-export function plainToInstance<T, V>(cls: ClassConstructor<T>, plain: V[], options?: ClassTransformOptions): T[];
-export function plainToInstance<T, V>(cls: ClassConstructor<T>, plain: V, options?: ClassTransformOptions): T;
-export function plainToInstance<T, V>(
+export function plainToInstance<T>(cls: ClassConstructor<T>, plain: T[], options?: ClassTransformOptions): T[];
+export function plainToInstance<T>(cls: ClassConstructor<T>, plain: T, options?: ClassTransformOptions): T;
+export function plainToInstance<T>(
   cls: ClassConstructor<T>,
-  plain: V | V[],
+  plain: T | T[],
   options?: ClassTransformOptions
 ): T | T[] {
   return classTransformer.plainToInstance(cls, plain as any, options);


### PR DESCRIPTION
## Description
Adds type-safe object literals to `plainToClass` / `plainToInstance`.

Untested but made [this proof of concept](https://www.typescriptlang.org/play?#code/C4TwDgpgBAwgNgQwM5JgewHZOAJwK4DGwaOAPACoB8UAvFAN4BQULUGEA7lABQB0-CHAHMkALigIMIANoBdAJTjyAbkYBfVYwAmEAohzQAZngxEAlpihhEZjOTTxkSCpW56xsRCnRZchYmRUADRWNhhKilAqjIx6TlAAYmhoDMysGAgAthDi2Di2QrRQAOQAEhBwcGjFqmoxBJjYUIbJRdYItvaOKNxJaCFMrGxZOSUAQoLFQWkstgBuCHBmWuLFYDhoYAByI1Pq8kA).

```ts
declare function plainToClass<T>(cls: ClassConstructor<T>, plain: T): T;

class Foo {
    name: string = 'Hello';
}

const foo = plainToClass(Foo, {
    name: 'Bar',
    invalid: 'propName',
})
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [ ] I have run the project locally and verified that there are no errors

### Fixes
Fixes #503
