### PR TITLE
feat: add instanceToPlainAsync method to handle promise values

### DIFF
--- a/src/ClassTransformer.ts
+++ b/src/ClassTransformer.ts
@@ -3,6 +3,7 @@ import { TransformOperationExecutor } from './TransformOperationExecutor';
 import { TransformationType } from './enums';
 import { ClassConstructor } from './interfaces';
 import { defaultOptions } from './constants/default-options.constant';
+import { instanceToPlainAsync } from './utils';
 
 export class ClassTransformer {
   // -------------------------------------------------------------------------
@@ -23,6 +24,26 @@ export class ClassTransformer {
       ...options,
     });
     return executor.transform(undefined, object, undefined, undefined, undefined, undefined);
+  }
+
+  /**
+   * Converts class (constructor) object to plain (literal) object with support to promise values resolution
+   */
+
+  instanceToPlainAsync<T extends Record<string, any>>(object: T, options?: ClassTransformOptions): Record<string, any>;
+  instanceToPlainAsync<T extends Record<string, any>>(
+    object: T[],
+    options?: ClassTransformOptions
+  ): Record<string, any>[];
+  instanceToPlainAsync<T extends Record<string, any>>(
+    object: T | T[],
+    options?: ClassTransformOptions
+  ): Record<string, any> | Record<string, any>[] {
+    const executor = new TransformOperationExecutor(TransformationType.CLASS_TO_PLAIN, {
+      ...defaultOptions,
+      ...options,
+    });
+    return instanceToPlainAsync(executor.transform(undefined, object, undefined, undefined, undefined, undefined));
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,18 @@ export function instanceToPlain<T>(
 }
 
 /**
+ * Converts class (constructor) object to plain (literal) object with support to promise values resolution
+ */
+export function instanceToPlainAsync<T>(object: T, options?: ClassTransformOptions): Record<string, any>;
+export function instanceToPlainAsync<T>(object: T[], options?: ClassTransformOptions): Record<string, any>[];
+export function instanceToPlainAsync<T>(
+  object: T | T[],
+  options?: ClassTransformOptions
+): Record<string, any> | Record<string, any>[] {
+  return classTransformer.instanceToPlainAsync(object, options);
+}
+
+/**
  * Converts class (constructor) object to plain (literal) object.
  * Uses given plain object as source object (it means fills given plain object with data from class object).
  * Also works with arrays.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './get-global.util';
 export * from './is-promise.util';
+export * from './promise-values.util';

--- a/src/utils/promise-values.util.ts
+++ b/src/utils/promise-values.util.ts
@@ -1,0 +1,68 @@
+import { instanceToPlain } from '..';
+
+class FutureValue<T> {
+  constructor(private promise: Promise<T>) {}
+
+  public async getValue(): Promise<T> {
+    return await this.promise;
+  }
+}
+
+function futureValuesWrapper(value: any, promises: Promise<any>[]) {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (value[i] instanceof Promise) {
+        promises.push(value[i]);
+        value[i] = new FutureValue(value[i]);
+      } else {
+        value[i] = futureValuesWrapper(value[i], promises);
+      }
+    }
+  }
+
+  if (value instanceof Object) {
+    for (const key of Object.keys(value)) {
+      if (value[key] instanceof Promise) {
+        promises.push(value[key]);
+        value[key] = new FutureValue(value[key]);
+      } else {
+        value[key] = futureValuesWrapper(value[key], promises);
+      }
+    }
+  }
+
+  return value;
+}
+
+async function futureValuesUnwrapper(value: any) {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (value[i] instanceof FutureValue) {
+        value[i] = await value[i].getValue();
+      } else {
+        value[i] = await futureValuesUnwrapper(value[i]);
+      }
+    }
+  }
+
+  if (value instanceof Object) {
+    for (const key of Object.keys(value)) {
+      if (value[key] instanceof FutureValue) {
+        value[key] = await value[key].getValue();
+      } else {
+        value[key] = await futureValuesUnwrapper(value[key]);
+      }
+    }
+  }
+
+  return value;
+}
+
+export async function instanceToPlainAsync(valuex: any): Promise<Record<string, any>> {
+  const valuesPromises: Promise<any>[] = [];
+
+  const futureValues = futureValuesWrapper(instanceToPlain(valuex), valuesPromises);
+  await Promise.all(valuesPromises);
+
+  return futureValuesUnwrapper(futureValues);
+}


### PR DESCRIPTION
## Description
Add a new async instanceToPlain method that handles promise values, it uses the original instanceToPain, check recursively all properties, if some propertie is instance of Promise wrap it in a "futureValue" object and add that promise to a list of future values, when all promises are resolved all values are unwraped and replaced at the output JSON

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #549
