### PR TITLE
feat: add instanceToPlainAsync method to handle promise values

### DIFF
--- a/src/ClassTransformer.ts
+++ b/src/ClassTransformer.ts
@@ -3,6 +3,7 @@ import { TransformOperationExecutor } from './TransformOperationExecutor';
 import { TransformationType } from './enums';
 import { ClassConstructor } from './interfaces';
 import { defaultOptions } from './constants/default-options.constant';
+import { instanceToPlainAsync } from './utils';
 
 export class ClassTransformer {
   // -------------------------------------------------------------------------
@@ -23,6 +24,29 @@ export class ClassTransformer {
       ...options,
     });
     return executor.transform(undefined, object, undefined, undefined, undefined, undefined);
+  }
+
+  /**
+   * Converts class (constructor) object to plain (literal) object with support to promise values resolution
+   */
+
+  instanceToPlainAsync<T extends Record<string, any>>(object: T, options?: ClassTransformOptions): Record<string, any>;
+  instanceToPlainAsync<T extends Record<string, any>>(
+    object: T[],
+    options?: ClassTransformOptions
+  ): Record<string, any>[];
+  instanceToPlainAsync<T extends Record<string, any>>(
+    object: T | T[],
+    options?: ClassTransformOptions
+  ): Record<string, any> | Record<string, any>[] {
+    const executor = new TransformOperationExecutor(TransformationType.CLASS_TO_PLAIN, {
+      ...defaultOptions,
+      ...options,
+    });
+    return instanceToPlainAsync(
+      executor.transform(undefined, object, undefined, undefined, undefined, undefined),
+      this.instanceToPlain
+    );
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,18 @@ export function instanceToPlain<T>(
 }
 
 /**
+ * Converts class (constructor) object to plain (literal) object with support to promise values resolution
+ */
+export function instanceToPlainAsync<T>(object: T, options?: ClassTransformOptions): Record<string, any>;
+export function instanceToPlainAsync<T>(object: T[], options?: ClassTransformOptions): Record<string, any>[];
+export function instanceToPlainAsync<T>(
+  object: T | T[],
+  options?: ClassTransformOptions
+): Record<string, any> | Record<string, any>[] {
+  return classTransformer.instanceToPlainAsync(object, options);
+}
+
+/**
  * Converts class (constructor) object to plain (literal) object.
  * Uses given plain object as source object (it means fills given plain object with data from class object).
  * Also works with arrays.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './get-global.util';
 export * from './is-promise.util';
+export * from './promise-values.util';

--- a/src/utils/promise-values.util.ts
+++ b/src/utils/promise-values.util.ts
@@ -1,0 +1,56 @@
+function promisesTracker(value: any, promises: Promise<any>[]) {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (value[i] instanceof Promise) {
+        promises.push(value[i]);
+      } else {
+        promisesTracker(value, promises);
+      }
+    }
+  }
+
+  if (value instanceof Object) {
+    for (const key of Object.keys(value)) {
+      if (value[key] instanceof Promise) {
+        promises.push(value[key]);
+      } else {
+        promisesTracker(value[key], promises);
+      }
+    }
+  }
+
+  return value;
+}
+
+async function resolvePromises(value: any) {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (value[i] instanceof Promise) {
+        value[i] = await value[i];
+      } else {
+        value[i] = await resolvePromises(value[i]);
+      }
+    }
+  }
+
+  if (value instanceof Object) {
+    for (const key of Object.keys(value)) {
+      if (value[key] instanceof Promise) {
+        value[key] = await value[key];
+      } else {
+        value[key] = await resolvePromises(value[key]);
+      }
+    }
+  }
+
+  return value;
+}
+
+export async function instanceToPlainAsync(value: any, instanceToPlainMethod: any): Promise<Record<string, any>> {
+  const valuesPromises: Promise<any>[] = [];
+
+  promisesTracker(instanceToPlainMethod(value), valuesPromises);
+  await Promise.all(valuesPromises);
+
+  return resolvePromises(value);
+}

--- a/test/functional/transformer-async.spec.ts
+++ b/test/functional/transformer-async.spec.ts
@@ -1,0 +1,21 @@
+import 'reflect-metadata';
+import { defaultMetadataStorage } from '../../src/storage';
+import { Expose } from '../../src/decorators';
+import { instanceToPlainAsync } from '../../src/index';
+
+describe('applying a transformation at a class that contains promise value', () => {
+  beforeEach(() => defaultMetadataStorage.clear());
+  afterEach(() => defaultMetadataStorage.clear());
+
+  it('should resolve the promise value', async () => {
+    class User {
+      @Expose()
+      name: Promise<string> = new Promise(resolve => {
+        resolve('Jonathan');
+      });
+    }
+
+    const plainUser = await instanceToPlainAsync(new User());
+    expect(plainUser.name).toEqual('Jonathan');
+  });
+});


### PR DESCRIPTION
## Description
Add a new async instanceToPlain method that handles promise values, it uses the original instanceToPain, check recursively all properties, if some propertie is instance of Promise it adds the promise to a tracking list, after all promises resolved the values also are resolved

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #549
