### PR TITLE
fix: allow subTypes.name to be a number in DiscriminatorDescriptor

### DIFF
--- a/src/interfaces/decorator-options/type-discriminator-descriptor.interface.ts
+++ b/src/interfaces/decorator-options/type-discriminator-descriptor.interface.ts
@@ -18,7 +18,7 @@ export interface DiscriminatorDescriptor {
     /**
      * Name of the type.
      */
-    name: string;
+    name: string | number;
 
     /**
      * A class constructor which can be used to create the object.


### PR DESCRIPTION
## Description
Fixes https://github.com/typestack/class-transformer/issues/737 as it is a small fix, but very useful and needed.
It allows subTypes.name to be a number as well - useful when discriminating with a version property for example.

## Checklist
- [ x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [ x] the pull request targets the *default* branch of the repository (`develop`)
- [ x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [ ] I have run the project locally and verified that there are no errors

I did not edit the documentation as it doesn't mention the string type so it being a number is fine.

### Fixes
fixes #737
