### PR TITLE
Add support for parsing boolean strings

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -107,7 +107,11 @@ export class TransformOperationExecutor {
       return Number(value);
     } else if (targetType === Boolean && !isMap) {
       if (value === null || value === undefined) return value;
-      return Boolean(value);
+      if (this.options.parseBooleanStrings && typeof value === 'string') {
+        return value.toLowerCase() === 'true' || value === '1';
+      } else {
+        return Boolean(value);
+      }
     } else if ((targetType === Date || value instanceof Date) && !isMap) {
       if (value instanceof Date) {
         return new Date(value.valueOf());

--- a/src/constants/default-options.constant.ts
+++ b/src/constants/default-options.constant.ts
@@ -10,6 +10,7 @@ export const defaultOptions: Partial<ClassTransformOptions> = {
   excludePrefixes: undefined,
   exposeDefaultValues: false,
   exposeUnsetFields: true,
+  parseBooleanStrings: false,
   groups: undefined,
   ignoreDecorators: false,
   strategy: undefined,

--- a/src/interfaces/class-transformer-options.interface.ts
+++ b/src/interfaces/class-transformer-options.interface.ts
@@ -76,4 +76,12 @@ export interface ClassTransformOptions {
    * DEFAULT: `true`
    */
   exposeUnsetFields?: boolean;
+
+  /**
+   * When set to true, boolean fields with string `true` (case insensitive) or `1` as value will be converted to true, other
+   * string values will be converted to false.
+   *
+   * DEFAULT: `false`
+   */
+  parseBooleanStrings?: boolean;
 }

--- a/test/functional/implicit-type-declarations.spec.ts
+++ b/test/functional/implicit-type-declarations.spec.ts
@@ -102,6 +102,12 @@ describe('plainToInstance transforms built-in primitive types properly', () => {
 
     @Type()
     boolean2: boolean;
+
+    @Type()
+    boolean3: boolean;
+
+    @Type()
+    boolean4: boolean;
   }
 
   const result: Example = plainToInstance(
@@ -114,8 +120,10 @@ describe('plainToInstance transforms built-in primitive types properly', () => {
       number2: 100,
       boolean: 1,
       boolean2: 0,
+      boolean3: 'true',
+      boolean4: 'false',
     },
-    { enableImplicitConversion: true }
+    { enableImplicitConversion: true, parseBooleanStrings: true }
   );
 
   it('should recognize and convert to Date', () => {
@@ -140,5 +148,7 @@ describe('plainToInstance transforms built-in primitive types properly', () => {
   it('should recognize and convert to boolean', () => {
     expect(result.boolean).toBeTruthy();
     expect(result.boolean2).toBeFalsy();
+    expect(result.boolean3).toBeTruthy();
+    expect(result.boolean4).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Description

`class-transformer` is often used in NestJS projects to parse request bodies/params. The current version transforms the string 'false' to true and requires ugly workarounds to make it work as expected, see #626, https://stackoverflow.com/questions/59046629/boolean-parameter-in-request-body-is-always-true-in-nestjs-api an the other linked issues.

This PR adds configuration option `parseBooleanStrings`, which allows parsing boolean strings. It is disabled by default so that it does not break existing projects.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [ x ] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [ x ] the pull request targets the *default* branch of the repository (`develop`)
- [ x ] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [ x ] tests are added for the changes I made (if any source code was modified)
- [ x ] documentation added or updated
- [ x ] I have run the project locally and verified that there are no errors

### Fixes
fixes #626
fixes [#2170](https://github.com/typestack/class-validator/issues/2170)
fixes #306
