### PR TITLE
fix: exposeUnsetFields when useDefineForClassFields is set

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -341,12 +341,16 @@ export class TransformOperationExecutor {
             }
           }
 
-          if (finalValue !== undefined || this.options.exposeUnsetFields) {
+          if (finalValue !== undefined) {
             if (newValue instanceof Map) {
               newValue.set(newValueKey, finalValue);
             } else {
               newValue[newValueKey] = finalValue;
             }
+          }
+
+          if (finalValue === undefined && !this.options.exposeUnsetFields) {
+            delete newValue[newValueKey];
           }
         } else if (this.transformationType === TransformationType.CLASS_TO_CLASS) {
           let finalValue = subValue;
@@ -357,12 +361,16 @@ export class TransformOperationExecutor {
             value,
             this.transformationType
           );
-          if (finalValue !== undefined || this.options.exposeUnsetFields) {
+          if (finalValue !== undefined) {
             if (newValue instanceof Map) {
               newValue.set(newValueKey, finalValue);
             } else {
               newValue[newValueKey] = finalValue;
             }
+          }
+
+          if (finalValue === undefined && !this.options.exposeUnsetFields) {
+            delete newValue[newValueKey];
           }
         }
       }


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->

When `useDefineForClassFields` is `true` in tsconfig option `exposeUnsetFields` doesn't work. This pull request make force `exposeUnsetFields ` to remove property from class if `finalValue` is `undefined`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

