### PR TITLE
fix: do not apply custom name for instanceToPlain on toClassOnly and exposeAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,11 +785,11 @@ The `@Transform` decorator is given more arguments to let you configure how you 
 
 ## Other decorators[⬆](#table-of-contents)
 
-| Signature                | Example                                              | Description                                                                           |
-| ------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `@TransformClassToPlain` | `@TransformClassToPlain({ groups: ["user"] })`       | Transform the method return with instanceToPlain and expose the properties on the class. |
+| Signature                | Example                                              | Description                                                                                 |
+| ------------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `@TransformClassToPlain` | `@TransformClassToPlain({ groups: ["user"] })`       | Transform the method return with instanceToPlain and expose the properties on the class.    |
 | `@TransformClassToClass` | `@TransformClassToClass({ groups: ["user"] })`       | Transform the method return with instanceToInstance and expose the properties on the class. |
-| `@TransformPlainToClass` | `@TransformPlainToClass(User, { groups: ["user"] })` | Transform the method return with plainToInstance and expose the properties on the class. |
+| `@TransformPlainToClass` | `@TransformPlainToClass(User, { groups: ["user"] })` | Transform the method return with plainToInstance and expose the properties on the class.    |
 
 The above decorators accept one optional argument:
 ClassTransformOptions - The transform options like groups, version, name

--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -184,7 +184,10 @@ export class TransformOperationExecutor {
             this.transformationType === TransformationType.CLASS_TO_CLASS
           ) {
             const exposeMetadata = defaultMetadataStorage.findExposeMetadata(targetType as Function, key);
-            if (exposeMetadata && exposeMetadata.options && exposeMetadata.options.name) {
+            const shouldRunOnToPlain = !(
+              exposeMetadata?.options?.toPlainOnly === false || exposeMetadata?.options?.toClassOnly === true
+            );
+            if (exposeMetadata && exposeMetadata.options && exposeMetadata.options.name && shouldRunOnToPlain) {
               newValueKey = exposeMetadata.options.name;
             }
           }

--- a/test/functional/transformation-option.spec.ts
+++ b/test/functional/transformation-option.spec.ts
@@ -188,3 +188,75 @@ describe('filtering by transformation option', () => {
     });
   });
 });
+
+describe('Filtering by transform options, name using ExposeAll strategy', () => {
+  it('@Expose with custom name and toClassOnly set to true then it should be exposed only during plainToInstance', () => {
+    defaultMetadataStorage.clear();
+
+    class User {
+      @Expose()
+      firstName: string;
+
+      @Expose()
+      lastName: string;
+
+      @Expose({ name: 'pass', toClassOnly: true })
+      password: string;
+    }
+
+    const plainUser = {
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      pass: 'imnosuperman',
+    };
+    const classedUser = plainToInstance(User, plainUser, { strategy: 'exposeAll' });
+    expect(classedUser).toBeInstanceOf(User);
+    expect(classedUser).toEqual({
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      password: 'imnosuperman',
+    });
+
+    const plainedUser = instanceToPlain(classedUser, { strategy: 'exposeAll' });
+    expect(plainedUser).toEqual({
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      password: 'imnosuperman',
+    });
+  });
+
+  it('@Expose with custom name and toPlainOnly set to true should be exposed only during instanceToPlain and classToPlainFromExist operations', () => {
+    defaultMetadataStorage.clear();
+
+    class User {
+      @Expose()
+      firstName: string;
+
+      @Expose()
+      lastName: string;
+
+      @Expose({ name: 'pass', toPlainOnly: true })
+      password: string;
+    }
+
+    const plainUser = {
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      password: 'imnosuperman',
+    };
+    const classedUser = plainToInstance(User, plainUser, { strategy: 'exposeAll' });
+    expect(classedUser).toBeInstanceOf(User);
+    expect(classedUser).toEqual({
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      password: 'imnosuperman',
+    });
+
+    const plainedUser = instanceToPlain(classedUser, { strategy: 'exposeAll' });
+    expect(plainedUser).toEqual({
+      firstName: 'Umed',
+      lastName: 'Khudoiberdiev',
+      pass: 'imnosuperman',
+    });
+  });
+});


### PR DESCRIPTION
## Description
The following code do not run as expected with 'exposeAll' strategy.

```typescript
class User {
  @Expose({ name: 'pass', toClassOnly: true })
  password: string;
}

const user = new User();
user.password = 'StrongPassword'

const plainedUser = instanceToPlain(user, {strategy: 'exposeAll'});
expect(plainedUser).toEqual({
  password: 'StrongPassword',
});
/**
 * Fails
 * 
 * - Expected  - 1
 * + Received  + 1
 *
 *   Object {
 * -   "password": "StrongPassword",
 * +   "pass": "StrongPassword",
 *   }
 */
```


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes https://github.com/typestack/class-transformer/issues/1324