### PR TITLE
fix: allow plain to class to convert from Set to Set instead of from Set to Array

### DIFF
--- a/test/functional/es6-data-types.spec.ts
+++ b/test/functional/es6-data-types.spec.ts
@@ -102,6 +102,51 @@ describe('es6 data types', () => {
     });
   });
 
+  it('using Set as source value', () => {
+    defaultMetadataStorage.clear();
+
+    class User {
+      id: number;
+      name: string;
+      @Type(() => Set)
+      weapons: Set<string>;
+    }
+
+    const plainUser = {
+      id: 1,
+      name: 'Max Pain',
+      weapons: new Set(['knife', 'eagle', 'ak-47']),
+    };
+
+    const weapons = new Set<string>();
+    weapons.add('knife');
+    weapons.add('eagle');
+    weapons.add('ak-47');
+
+    const user = new User();
+    user.id = 1;
+    user.name = 'Max Pain';
+    user.weapons = weapons;
+
+    const classedUser = plainToInstance(User, plainUser);
+    expect(classedUser).toBeInstanceOf(User);
+    expect(classedUser.id).toEqual(1);
+    expect(classedUser.name).toEqual('Max Pain');
+    expect(classedUser.weapons).toBeInstanceOf(Set);
+    expect(classedUser.weapons.size).toEqual(3);
+    expect(classedUser.weapons.has('knife')).toBeTruthy();
+    expect(classedUser.weapons.has('eagle')).toBeTruthy();
+    expect(classedUser.weapons.has('ak-47')).toBeTruthy();
+
+    const plainedUser = instanceToPlain(user);
+    expect(plainedUser).not.toBeInstanceOf(User);
+    expect(plainedUser).toEqual({
+      id: 1,
+      name: 'Max Pain',
+      weapons: ['knife', 'eagle', 'ak-47'],
+    });
+  });
+
   it('using Map with objects', () => {
     defaultMetadataStorage.clear();
 


### PR DESCRIPTION
## Description
Allow conversion from plain values containing Sets to Sets instead of Array.

## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #1723
