### PR TITLE
Enhance boolean conversion logic for strings and numeric values

### DIFF
--- a/src/TransformOperationExecutor.ts
+++ b/src/TransformOperationExecutor.ts
@@ -107,6 +107,9 @@ export class TransformOperationExecutor {
       return Number(value);
     } else if (targetType === Boolean && !isMap) {
       if (value === null || value === undefined) return value;
+      if (typeof value === 'string' && !isNaN(parseFloat(value))) return Boolean(+value);
+      if (typeof value === 'string' && ['true', 'false'].includes(value.toLowerCase()))
+        return value.toLowerCase() === 'true';
       return Boolean(value);
     } else if ((targetType === Date || value instanceof Date) && !isMap) {
       if (value instanceof Date) {

--- a/test/functional/implicit-type-declarations.spec.ts
+++ b/test/functional/implicit-type-declarations.spec.ts
@@ -102,6 +102,24 @@ describe('plainToInstance transforms built-in primitive types properly', () => {
 
     @Type()
     boolean2: boolean;
+
+    @Type()
+    boolean3: boolean;
+
+    @Type()
+    boolean4: boolean;
+
+    @Type()
+    boolean5: boolean;
+
+    @Type()
+    boolean6: boolean;
+
+    @Type()
+    boolean7: boolean;
+
+    @Type()
+    boolean8: boolean;
   }
 
   const result: Example = plainToInstance(
@@ -114,6 +132,12 @@ describe('plainToInstance transforms built-in primitive types properly', () => {
       number2: 100,
       boolean: 1,
       boolean2: 0,
+      boolean3: 'true',
+      boolean4: 'false',
+      boolean5: '1',
+      boolean6: '0',
+      boolean7: '',
+      boolean8: 'yes',
     },
     { enableImplicitConversion: true }
   );
@@ -140,5 +164,11 @@ describe('plainToInstance transforms built-in primitive types properly', () => {
   it('should recognize and convert to boolean', () => {
     expect(result.boolean).toBeTruthy();
     expect(result.boolean2).toBeFalsy();
+    expect(result.boolean3).toBeTruthy();
+    expect(result.boolean4).toBeFalsy();
+    expect(result.boolean5).toBeTruthy();
+    expect(result.boolean6).toBeFalsy();
+    expect(result.boolean7).toBeFalsy();
+    expect(result.boolean8).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Description
This update improves the boolean conversion logic when handling string values in the type mapping. The changes include:

* Converting strings representing numbers (e.g., '1', '0') to booleans.
* Handling specific string values like 'true' and 'false' to map them to their correct boolean counterparts.

This ensures more consistent and accurate conversions when dealing with strings that are either numeric or represent boolean values.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
fixes #676, fixes #626 

This fix ensures that query parameters sent as strings, which are common in NestJS, are correctly converted to booleans when using class-transformer. It prevents incorrect boolean conversions that previously resulted in all such values being interpreted as true.
For exemple have '1', '0', 'true', 'false' result to having true.
