### PR TITLE
feat: add type arguments in transform decorator

### DIFF
--- a/sample/sample6-type-arguments/app.ts
+++ b/sample/sample6-type-arguments/app.ts
@@ -1,0 +1,17 @@
+import { plainToInstance, Transform } from '../../src';
+
+interface CSVInvoiceRecord {
+  net: string;
+}
+
+class Invoice {
+  @Transform<CSVInvoiceRecord, 'net', number>(({ value }) => Number(value.replace(',', '')))
+  net: number;
+}
+
+const rawInvoice: CSVInvoiceRecord = {
+  net: '2,000',
+};
+
+const invoice = plainToInstance(Invoice, rawInvoice);
+console.log(invoice);

--- a/src/decorators/transform.decorator.ts
+++ b/src/decorators/transform.decorator.ts
@@ -6,8 +6,8 @@ import { TransformFnParams, TransformOptions } from '../interfaces';
  *
  * Can be applied to properties only.
  */
-export function Transform(
-  transformFn: (params: TransformFnParams) => any,
+export function Transform<T extends Record<string, any> = any, K extends keyof T = any, R = any>(
+  transformFn: (params: TransformFnParams<T, K>) => R,
   options: TransformOptions = {}
 ): PropertyDecorator {
   return function (target: any, propertyName: string | Symbol): void {

--- a/src/interfaces/metadata/transform-fn-params.interface.ts
+++ b/src/interfaces/metadata/transform-fn-params.interface.ts
@@ -1,10 +1,10 @@
 import { TransformationType } from '../../enums';
 import { ClassTransformOptions } from '../class-transformer-options.interface';
 
-export interface TransformFnParams {
-  value: any;
+export interface TransformFnParams<T extends Record<string, any> = any, K extends keyof T = any> {
+  value: T[K];
   key: string;
-  obj: any;
+  obj: T;
   type: TransformationType;
   options: ClassTransformOptions;
 }

--- a/test/functional/custom-transform.spec.ts
+++ b/test/functional/custom-transform.spec.ts
@@ -783,6 +783,28 @@ describe('custom transformation decorator', () => {
     }).not.toThrow();
   });
 
+  it('should serialize json to invoice instance of class Invoice with type arguments', () => {
+    defaultMetadataStorage.clear();
+    expect(() => {
+      interface CSVInvoiceRecord {
+        net: string;
+      }
+
+      class Invoice {
+        @Transform<CSVInvoiceRecord, 'net', number>(({ value }) => Number(value.replace(',', '')))
+        net: number;
+      }
+
+      const rawInvoice: CSVInvoiceRecord = {
+        net: '2,000',
+      };
+
+      const invoice = plainToInstance(Invoice, rawInvoice);
+      expect(invoice).toBeInstanceOf(Invoice);
+      expect(invoice.net).toEqual(2000);
+    }).not.toThrow();
+  });
+
   it('should serialize a model into json', () => {
     expect(() => {
       instanceToPlain(model);


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
Add type arguments in Transform decorator for help to make a type-safe easier

### Example usage
```typescript
interface CSVInvoiceRecord {
  net: string;
}

class Invoice {
  @Transform<CSVInvoiceRecord, 'net', number>(({ value }) => Number(value.replace(',', '')))
  net: number;
}
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [x] documentation added or updated
- [x] I have run the project locally and verified that there are no errors
